### PR TITLE
fix: resolve plan UX issues #27-#32 and bump to v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-03-28
+
+### Added
+
+- Finish time input mode in plan creation: toggle between target pace (min/km) and target finish time (H:MM:SS), with automatic conversion (#29)
+- Level descriptions across the app: each difficulty level (beginner, intermediate, advanced, elite) now shows concrete frequency and weekly volume expectations (#28)
+- Plan context banner on workout detail page: when viewing a session from a plan, shows the scaled duration based on the week's volume percentage (#32)
+
+### Changed
+
+- Plan duration warning redesigned: now shows specific risks (mental fatigue, overtraining) and suggests alternatives instead of a vague "not recommended" message (#27)
+- Stats section: "Distance par semaine" renamed to "Kilométrage hebdomadaire" and "Volume par semaine" renamed to "Temps d'entraînement hebdomadaire" with descriptive subtitles (#30)
+
+### Fixed
+
+- Navigating back from a workout detail page now returns to the correct week in the weekly plan view instead of resetting to week 1 (#31)
+- Workout detail page now displays the plan-scaled duration when accessed from a plan, instead of always showing the base session duration (#32)
+
 ## [0.3.0] - 2026-03-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zoned",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,11 +72,14 @@ function preloadSidebarPages() {
 }
 
 function ScrollToTopOnNavigate() {
-  const { pathname } = useLocation();
+  const location = useLocation();
 
   useEffect(() => {
+    // Skip scroll-to-top when returning to a plan from workout detail
+    const state = location.state as { returnToWeek?: number } | null;
+    if (state?.returnToWeek) return;
     window.scrollTo(0, 0);
-  }, [pathname]);
+  }, [location.pathname, location.state]);
 
   return null;
 }

--- a/src/components/domain/PlanStatsSection.tsx
+++ b/src/components/domain/PlanStatsSection.tsx
@@ -315,8 +315,13 @@ export const PlanStatsSection = memo(function PlanStatsSection({ plan, currentWe
         {weeklyKmData.some(w => w.km > 0) && (
           <div className="space-y-2">
             <h3 className="text-sm font-medium">
-              {isEn ? "Weekly distance (km)" : "Distance par semaine (km)"}
+              {isEn ? "Weekly mileage (km)" : "Kilométrage hebdomadaire (km)"}
             </h3>
+            <p className="text-xs text-muted-foreground">
+              {isEn
+                ? "Planned kilometers for each week"
+                : "Kilomètres planifiés pour chaque semaine"}
+            </p>
             <div className="flex items-end gap-[2px] h-28">
               {weeklyKmData.map((week) => {
                 const heightPct = maxWeeklyKm > 0 ? (week.km / maxWeeklyKm) * 100 : 0;
@@ -355,8 +360,13 @@ export const PlanStatsSection = memo(function PlanStatsSection({ plan, currentWe
         {/* ── Section 2b: Weekly Volume (minutes) Chart ───────────── */}
         <div className="space-y-2">
           <h3 className="text-sm font-medium">
-            {isEn ? "Weekly volume" : "Volume par semaine"}
+            {isEn ? "Weekly training time (min)" : "Temps d'entraînement hebdomadaire (min)"}
           </h3>
+          <p className="text-xs text-muted-foreground">
+            {isEn
+              ? "Total estimated duration per week (warmup + workout + cooldown)"
+              : "Durée totale estimée par semaine (échauffement + séance + retour au calme)"}
+          </p>
           <div className="flex items-end gap-[2px] h-32">
             {stats.weeklyVolumes.map((week) => {
               const heightPercent =

--- a/src/components/domain/PlanWeeklyView.tsx
+++ b/src/components/domain/PlanWeeklyView.tsx
@@ -48,6 +48,7 @@ interface PlanWeeklyViewProps {
   plan: TrainingPlan;
   workoutNames: Record<string, string>;
   currentWeek: number;
+  initialWeek?: number;
   isEn: boolean;
   onSessionClick?: (weekNumber: number, sessionIndex: number, workoutId: string) => void;
   onSessionMove?: (
@@ -69,6 +70,7 @@ export const PlanWeeklyView = memo(function PlanWeeklyView({
   plan,
   workoutNames,
   currentWeek,
+  initialWeek,
   isEn,
   onSessionClick,
   onSessionMove,
@@ -79,7 +81,7 @@ export const PlanWeeklyView = memo(function PlanWeeklyView({
   onAddToDay,
 }: PlanWeeklyViewProps) {
   // ── Week navigation state ──────────────────────────────────────
-  const [selectedWeek, setSelectedWeek] = useState(Math.max(1, currentWeek));
+  const [selectedWeek, setSelectedWeek] = useState(Math.max(1, initialWeek ?? currentWeek));
 
   const weekData = useMemo(
     () => plan.weeks.find((w) => w.weekNumber === selectedWeek),

--- a/src/components/domain/WorkoutStructure.tsx
+++ b/src/components/domain/WorkoutStructure.tsx
@@ -11,27 +11,33 @@ interface WorkoutStructureProps {
   workout: WorkoutTemplate;
   userZones?: ZoneRange[];
   className?: string;
+  /** Volume scaling (0-100) from plan context. Scales main set durations. */
+  volumePercent?: number;
 }
 
-export function WorkoutStructure({ workout, userZones, className }: WorkoutStructureProps) {
+export function WorkoutStructure({ workout, userZones, className, volumePercent }: WorkoutStructureProps) {
   const { t, i18n } = useTranslation("session");
   const isEn = i18n.language?.startsWith("en") ?? false;
+  const scale = volumePercent != null && volumePercent !== 100 ? volumePercent / 100 : null;
 
   const phases = [
     {
       key: "warmup",
       label: t("structure.warmup"),
       blocks: workout.warmupTemplate,
+      scale: null,
     },
     {
       key: "main",
       label: t("structure.main"),
       blocks: workout.mainSetTemplate,
+      scale, // only scale main set
     },
     {
       key: "cooldown",
       label: t("structure.cooldown"),
       blocks: workout.cooldownTemplate,
+      scale: null,
     },
   ].filter((phase) => phase.blocks.length > 0);
 
@@ -44,7 +50,7 @@ export function WorkoutStructure({ workout, userZones, className }: WorkoutStruc
           </h4>
           <div className="space-y-2">
             {phase.blocks.map((block, index) => (
-              <BlockItem key={index} block={block} isEn={isEn} userZones={userZones} />
+              <BlockItem key={index} block={block} isEn={isEn} userZones={userZones} durationScale={phase.scale} />
             ))}
           </div>
         </div>
@@ -57,6 +63,7 @@ interface BlockItemProps {
   block: WorkoutBlock;
   isEn: boolean;
   userZones?: ZoneRange[];
+  durationScale?: number | null;
 }
 
 /**
@@ -81,7 +88,7 @@ function formatPersonalizedZone(zoneNumber: ZoneNumber, userZones: ZoneRange[]):
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
-function BlockItem({ block, isEn, userZones }: BlockItemProps) {
+function BlockItem({ block, isEn, userZones, durationScale }: BlockItemProps) {
   const description = isEn && block.descriptionEn
     ? block.descriptionEn
     : block.description;
@@ -91,9 +98,12 @@ function BlockItem({ block, isEn, userZones }: BlockItemProps) {
     ? formatPersonalizedZone(zoneNumber, userZones)
     : null;
 
-  // Build duration/meta string
+  // Build duration/meta string (scale if from plan)
   const metaParts: string[] = [];
-  if (block.durationMin) metaParts.push(`${block.durationMin} min`);
+  if (block.durationMin) {
+    const scaledDuration = durationScale ? Math.round(block.durationMin * durationScale) : block.durationMin;
+    metaParts.push(`${scaledDuration} min`);
+  }
   if (block.repetitions && block.repetitions > 1) metaParts.push(`${block.repetitions}x`);
   if (block.distance) metaParts.push(block.distance);
   const metaString = metaParts.join(" · ");

--- a/src/components/visualization/SessionTimeline.tsx
+++ b/src/components/visualization/SessionTimeline.tsx
@@ -24,6 +24,8 @@ import {
 interface SessionTimelineProps {
   workout: WorkoutTemplate;
   className?: string;
+  /** Volume scaling (0-100) from plan context. Scales main set durations. */
+  volumePercent?: number;
 }
 
 /**
@@ -92,7 +94,7 @@ function SegmentTooltipContent({ segment, t }: SegmentTooltipContentProps) {
   );
 }
 
-export function SessionTimeline({ workout, className }: SessionTimelineProps) {
+export function SessionTimeline({ workout, className, volumePercent }: SessionTimelineProps) {
   const { t, i18n } = useTranslation("session");
   const isEn = i18n.language?.startsWith("en") ?? false;
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -105,9 +107,10 @@ export function SessionTimeline({ workout, className }: SessionTimelineProps) {
         mainSet: workout.mainSetTemplate,
         cooldown: workout.cooldownTemplate,
       },
-      isEn
+      isEn,
+      volumePercent
     );
-  }, [workout, isEn]);
+  }, [workout, isEn, volumePercent]);
 
   if (segments.length === 0) {
     return (

--- a/src/components/visualization/ZoneDistribution.tsx
+++ b/src/components/visualization/ZoneDistribution.tsx
@@ -12,9 +12,11 @@ import { cn } from "@/lib/utils";
 interface ZoneDistributionProps {
   workout: WorkoutTemplate;
   className?: string;
+  /** Volume scaling (0-100) from plan context. Scales main set durations. */
+  volumePercent?: number;
 }
 
-export function ZoneDistribution({ workout, className }: ZoneDistributionProps) {
+export function ZoneDistribution({ workout, className, volumePercent }: ZoneDistributionProps) {
   const { i18n } = useTranslation();
   const isEn = i18n.language?.startsWith("en") ?? false;
 
@@ -25,9 +27,10 @@ export function ZoneDistribution({ workout, className }: ZoneDistributionProps) 
         mainSet: workout.mainSetTemplate,
         cooldown: workout.cooldownTemplate,
       },
-      isEn
+      isEn,
+      volumePercent
     );
-  }, [workout, isEn]);
+  }, [workout, isEn, volumePercent]);
 
   if (zoneBreakdown.length === 0) {
     return null;

--- a/src/components/visualization/transforms.ts
+++ b/src/components/visualization/transforms.ts
@@ -325,13 +325,16 @@ function blockToSegments(
 
 /**
  * Transform session blocks into complete visualization data
+ * @param volumePercent - optional volume scaling (0-100) from plan context. Only scales main set segments.
  */
 export function transformSessionBlocks(
   blocks: SessionBlocks,
-  isEn: boolean = false
+  isEn: boolean = false,
+  volumePercent?: number
 ): SessionVisualizationData {
   const allSegments: TimelineSegment[] = [];
   let segmentIndex = 0;
+  const scale = volumePercent != null ? volumePercent / 100 : 1;
 
   // Process each block type in order
   const blockTypes: Array<{ type: BlockType; blocks: WorkoutBlock[] }> = [
@@ -343,6 +346,12 @@ export function transformSessionBlocks(
   for (const { type, blocks: typeBlocks } of blockTypes) {
     for (const block of typeBlocks) {
       const segments = blockToSegments(block, type, segmentIndex);
+      // Scale main set durations when volumePercent is provided
+      if (type === "main" && scale !== 1) {
+        for (const seg of segments) {
+          seg.durationMin = seg.durationMin * scale;
+        }
+      }
       allSegments.push(...segments);
       segmentIndex++;
     }

--- a/src/i18n/locales/en/plan.json
+++ b/src/i18n/locales/en/plan.json
@@ -70,7 +70,8 @@
     "subtitle": "At least {{min}} weeks from today",
     "weeks": "{{count}} weeks of preparation",
     "tooSoon": "Too close! You need at least {{min}} weeks.",
-    "tooLong": "Over {{max}} weeks is not recommended for this distance, but it's possible."
+    "tooLong": "{{weeks}} weeks is a long cycle",
+    "tooLongDetail": "For this distance, {{min}}–{{max}} weeks is ideal. Beyond that, you risk mental fatigue and overtraining. Consider a base building block before your specific preparation."
   },
   "raceName": {
     "title": "Race name",
@@ -83,9 +84,13 @@
     "subtitle": "Select your current level",
     "vmaSuggestion": "Based on your VMA of {{vma}} km/h, we suggest:",
     "beginner": "Beginner",
+    "beginnerDesc": "1–2 runs/week · less than 15 km/week",
     "intermediate": "Intermediate",
+    "intermediateDesc": "3–4 runs/week · 20–40 km/week",
     "advanced": "Advanced",
-    "elite": "Elite"
+    "advancedDesc": "4–5 runs/week · 40–70 km/week",
+    "elite": "Elite",
+    "eliteDesc": "5–7 runs/week · 70+ km/week"
   },
   "config": {
     "title": "Configuration",
@@ -97,8 +102,14 @@
     "title": "Pace & Elevation",
     "subtitle": "Optional - specify your goals",
     "targetPace": "Target pace (min/km)",
+    "targetTime": "Finish time",
+    "targetPaceTab": "Target pace",
+    "targetTimeTab": "Finish time",
     "pacePlaceholder": "E.g.: 5:30",
+    "timePlaceholder": "E.g.: 3:30 or 3:30:00",
     "estimatedTime": "Estimated time: {{time}}",
+    "requiredPace": "Required pace: {{pace}} min/km",
+    "timeFormatHint": "Format: H:MM or H:MM:SS (e.g. 3:30 or 3:30:00)",
     "elevation": "Elevation gain (m)",
     "elevationPlaceholder": "E.g.: 500",
     "skip": "Skip this step"
@@ -168,8 +179,10 @@
     "peakWeek": "Peak week",
     "longestSession": "Longest",
     "recoveryWeeks": "Recovery wk",
-    "weeklyVolume": "Weekly volume",
-    "weeklyKm": "Weekly distance (km)",
+    "weeklyVolume": "Weekly training time (min)",
+    "weeklyVolumeDesc": "Total estimated duration per week (warmup + workout + cooldown)",
+    "weeklyKm": "Weekly mileage (km)",
+    "weeklyKmDesc": "Planned kilometers for each week",
     "sessionTypes": "Session types",
     "zoneDistribution": "Zone distribution",
     "targetSystems": "Target systems",

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -85,5 +85,9 @@
       "nutrition": "Complete nutrition guide",
       "recovery": "Complete recovery guide"
     }
+  },
+  "planContext": {
+    "banner": "In your plan (week {{week}}, {{volume}}% volume): ~{{duration}} min",
+    "fullSession": "(full session: {{duration}} min)"
   }
 }

--- a/src/i18n/locales/fr/plan.json
+++ b/src/i18n/locales/fr/plan.json
@@ -70,7 +70,8 @@
     "subtitle": "Au minimum {{min}} semaines à partir d'aujourd'hui",
     "weeks": "{{count}} semaines de préparation",
     "tooSoon": "Trop proche ! Il faut au moins {{min}} semaines.",
-    "tooLong": "Plus de {{max}} semaines n'est pas recommandé pour cette distance, mais c'est possible."
+    "tooLong": "{{weeks}} semaines, c'est un cycle long",
+    "tooLongDetail": "Pour cette distance, {{min}}–{{max}} semaines est idéal. Au-delà, tu risques la fatigue mentale et le surentraînement. Envisage un bloc de base building avant ta préparation spécifique."
   },
   "raceName": {
     "title": "Nom de la course",
@@ -83,9 +84,13 @@
     "subtitle": "Sélectionnez votre niveau actuel",
     "vmaSuggestion": "Basé sur votre VMA de {{vma}} km/h, nous suggérons :",
     "beginner": "Débutant",
+    "beginnerDesc": "1 à 2 sorties/semaine · moins de 15 km/semaine",
     "intermediate": "Intermédiaire",
+    "intermediateDesc": "3 à 4 sorties/semaine · 20–40 km/semaine",
     "advanced": "Avancé",
-    "elite": "Élite"
+    "advancedDesc": "4 à 5 sorties/semaine · 40–70 km/semaine",
+    "elite": "Élite",
+    "eliteDesc": "5 à 7 sorties/semaine · 70+ km/semaine"
   },
   "config": {
     "title": "Configuration",
@@ -97,8 +102,14 @@
     "title": "Allure & Dénivelé",
     "subtitle": "Optionnel - précisez vos objectifs",
     "targetPace": "Allure cible (min/km)",
+    "targetTime": "Temps cible",
+    "targetPaceTab": "Allure cible",
+    "targetTimeTab": "Temps cible",
     "pacePlaceholder": "Ex: 5:30",
+    "timePlaceholder": "Ex: 3:30 ou 3:30:00",
     "estimatedTime": "Temps estimé : {{time}}",
+    "requiredPace": "Allure nécessaire : {{pace}} min/km",
+    "timeFormatHint": "Format : H:MM ou H:MM:SS (ex. 3:30 ou 3:30:00)",
     "elevation": "Dénivelé positif (m)",
     "elevationPlaceholder": "Ex: 500",
     "skip": "Passer cette étape"
@@ -168,8 +179,10 @@
     "peakWeek": "Semaine pic",
     "longestSession": "Session max",
     "recoveryWeeks": "Sem. récup",
-    "weeklyVolume": "Volume par semaine",
-    "weeklyKm": "Distance par semaine (km)",
+    "weeklyVolume": "Temps d'entraînement hebdomadaire (min)",
+    "weeklyVolumeDesc": "Durée totale estimée par semaine (échauffement + séance + retour au calme)",
+    "weeklyKm": "Kilométrage hebdomadaire (km)",
+    "weeklyKmDesc": "Kilomètres planifiés pour chaque semaine",
     "sessionTypes": "Types de séance",
     "zoneDistribution": "Répartition par zone",
     "targetSystems": "Systèmes ciblés",

--- a/src/i18n/locales/fr/session.json
+++ b/src/i18n/locales/fr/session.json
@@ -85,5 +85,9 @@
       "nutrition": "Guide nutrition complet",
       "recovery": "Guide récupération complet"
     }
+  },
+  "planContext": {
+    "banner": "Dans votre plan (semaine {{week}}, {{volume}}% volume) : ~{{duration}} min",
+    "fullSession": "(séance complète : {{duration}} min)"
   }
 }

--- a/src/pages/PlanCreatePage.tsx
+++ b/src/pages/PlanCreatePage.tsx
@@ -147,6 +147,32 @@ function estimateFinishTime(
   return `${minutes}min${seconds.toString().padStart(2, "0")}s`;
 }
 
+function parseFinishTimeToSeconds(timeStr: string): number | null {
+  // Supports H:MM:SS, H:MM, HH:MM:SS, HH:MM, MM:SS (if no hours)
+  const full = timeStr.match(/^(\d{1,2}):(\d{2}):(\d{2})$/);
+  if (full) {
+    const h = parseInt(full[1], 10);
+    const m = parseInt(full[2], 10);
+    const s = parseInt(full[3], 10);
+    if (m >= 60 || s >= 60) return null;
+    return h * 3600 + m * 60 + s;
+  }
+  const short = timeStr.match(/^(\d{1,2}):(\d{2})$/);
+  if (short) {
+    const a = parseInt(short[1], 10);
+    const b = parseInt(short[2], 10);
+    if (b >= 60) return null;
+    // If a >= 1 and context suggests hours (for marathon-type distances), treat as H:MM
+    // We always treat as H:MM if a < 60
+    return a * 3600 + b * 60;
+  }
+  return null;
+}
+
+function finishTimeToPaceSeconds(finishTimeSeconds: number, distanceKm: number): number {
+  return finishTimeSeconds / distanceKm;
+}
+
 function generateId(): string {
   return `plan-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -179,6 +205,8 @@ export function PlanCreatePage() {
 
   const [stepIndex, setStepIndex] = useState(0);
   const [direction, setDirection] = useState<"forward" | "backward">("forward");
+  const [paceInputMode, setPaceInputMode] = useState<"pace" | "time">("pace");
+  const [targetFinishTime, setTargetFinishTime] = useState("");
   const [form, setForm] = useState<FormState>({
     planPurpose: "race",
     trainingGoal: "time",
@@ -617,11 +645,18 @@ export function PlanCreatePage() {
           )}
 
           {form.raceDate && dateTooLong && (
-            <p className="text-sm text-amber-600 dark:text-amber-400 text-center">
-              {isEn
-                ? `Over ${recommendedWeeks.max} weeks is not recommended for this distance, but it's possible.`
-                : `Plus de ${recommendedWeeks.max} semaines n'est pas recommandé pour cette distance, mais c'est possible.`}
-            </p>
+            <div className="rounded-lg border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/30 p-3 text-sm text-amber-800 dark:text-amber-300 text-center space-y-1">
+              <p className="font-semibold">
+                {isEn
+                  ? `⚠️ ${weeksCount} weeks is a long cycle`
+                  : `⚠️ ${weeksCount} semaines, c'est un cycle long`}
+              </p>
+              <p className="text-xs">
+                {isEn
+                  ? `For this distance, ${recommendedWeeks.min}–${recommendedWeeks.max} weeks is ideal. Beyond that, you risk mental fatigue and overtraining. Consider a base building block before your specific preparation.`
+                  : `Pour cette distance, ${recommendedWeeks.min}–${recommendedWeeks.max} semaines est idéal. Au-delà, tu risques la fatigue mentale et le surentraînement. Envisage un bloc de base building avant ta préparation spécifique.`}
+              </p>
+            </div>
           )}
         </div>
       </div>
@@ -750,6 +785,9 @@ export function PlanCreatePage() {
                     <div className="min-w-0">
                       <div className="font-medium text-sm md:text-base leading-tight">
                         {isEn ? meta.labelEn : meta.label}
+                      </div>
+                      <div className="text-[11px] text-muted-foreground leading-tight mt-0.5">
+                        {isEn ? meta.descEn : meta.desc}
                       </div>
                       {isSuggested && (
                         <div className="text-xs text-primary">
@@ -1011,39 +1049,117 @@ export function PlanCreatePage() {
           )}
 
           <div className="w-full max-w-sm mt-6 space-y-4">
-            {/* Target pace */}
-            <div>
-              <label className="text-sm font-medium mb-2 block">
-                {isEn ? "Target pace (min/km)" : "Allure cible (min/km)"}
-              </label>
-              <input
-                type="text"
-                value={form.targetPace}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, targetPace: e.target.value }))
-                }
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && (paceSeconds || !form.targetPace)) goForward();
-                }}
-                placeholder="5:30"
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-              {paceSeconds && distanceKm > 0 && (
-                <p className="text-xs text-muted-foreground mt-1">
-                  {isEn ? "Estimated finish: " : "Temps estimé : "}
-                  <span className="font-medium">
-                    {estimateFinishTime(paceSeconds, distanceKm)}
-                  </span>
-                </p>
-              )}
-              {form.targetPace && !paceSeconds && (
-                <p className="text-xs text-destructive mt-1">
-                  {isEn
-                    ? "Format: MM:SS (e.g. 5:30)"
-                    : "Format : MM:SS (ex. 5:30)"}
-                </p>
-              )}
+            {/* Pace input mode toggle */}
+            <div className="flex rounded-lg border overflow-hidden">
+              <button
+                type="button"
+                className={cn(
+                  "flex-1 px-3 py-1.5 text-xs font-medium transition-colors",
+                  paceInputMode === "pace" ? "bg-primary text-primary-foreground" : "bg-background hover:bg-muted"
+                )}
+                onClick={() => setPaceInputMode("pace")}
+              >
+                {isEn ? "Target pace" : "Allure cible"}
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  "flex-1 px-3 py-1.5 text-xs font-medium transition-colors",
+                  paceInputMode === "time" ? "bg-primary text-primary-foreground" : "bg-background hover:bg-muted"
+                )}
+                onClick={() => setPaceInputMode("time")}
+              >
+                {isEn ? "Finish time" : "Temps cible"}
+              </button>
             </div>
+
+            {/* Target pace or finish time */}
+            {paceInputMode === "pace" ? (
+              <div>
+                <label className="text-sm font-medium mb-2 block">
+                  {isEn ? "Target pace (min/km)" : "Allure cible (min/km)"}
+                </label>
+                <input
+                  type="text"
+                  value={form.targetPace}
+                  onChange={(e) => {
+                    setForm((f) => ({ ...f, targetPace: e.target.value }));
+                    setTargetFinishTime("");
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (paceSeconds || !form.targetPace)) goForward();
+                  }}
+                  placeholder="5:30"
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                {paceSeconds && distanceKm > 0 && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {isEn ? "Estimated finish: " : "Temps estimé : "}
+                    <span className="font-medium">
+                      {estimateFinishTime(paceSeconds, distanceKm)}
+                    </span>
+                  </p>
+                )}
+                {form.targetPace && !paceSeconds && (
+                  <p className="text-xs text-destructive mt-1">
+                    {isEn
+                      ? "Format: MM:SS (e.g. 5:30)"
+                      : "Format : MM:SS (ex. 5:30)"}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div>
+                <label className="text-sm font-medium mb-2 block">
+                  {isEn ? "Target finish time" : "Temps d'arrivée visé"}
+                </label>
+                <input
+                  type="text"
+                  value={targetFinishTime}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setTargetFinishTime(val);
+                    const totalSec = parseFinishTimeToSeconds(val);
+                    if (totalSec && distanceKm > 0) {
+                      const paceSec = finishTimeToPaceSeconds(totalSec, distanceKm);
+                      setForm((f) => ({ ...f, targetPace: formatPace(paceSec) }));
+                    } else {
+                      setForm((f) => ({ ...f, targetPace: "" }));
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const totalSec = parseFinishTimeToSeconds(targetFinishTime);
+                      if (totalSec || !targetFinishTime) goForward();
+                    }
+                  }}
+                  placeholder={isEn ? "e.g. 3:30 or 3:30:00" : "ex. 3:30 ou 3:30:00"}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                {(() => {
+                  const totalSec = parseFinishTimeToSeconds(targetFinishTime);
+                  if (totalSec && distanceKm > 0) {
+                    const paceSec = finishTimeToPaceSeconds(totalSec, distanceKm);
+                    return (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {isEn ? "Required pace: " : "Allure nécessaire : "}
+                        <span className="font-medium">{formatPace(paceSec)} min/km</span>
+                      </p>
+                    );
+                  }
+                  if (targetFinishTime && !totalSec) {
+                    return (
+                      <p className="text-xs text-destructive mt-1">
+                        {isEn
+                          ? "Format: H:MM or H:MM:SS (e.g. 3:30 or 3:30:00)"
+                          : "Format : H:MM ou H:MM:SS (ex. 3:30 ou 3:30:00)"}
+                      </p>
+                    );
+                  }
+                  return null;
+                })()}
+              </div>
+            )}
 
             {/* Elevation gain */}
             <div>

--- a/src/pages/PlanCreatePage.tsx
+++ b/src/pages/PlanCreatePage.tsx
@@ -16,6 +16,7 @@ import {
   Heart,
   Footprints,
   TrendingUp,
+  AlertTriangle,
 } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -646,10 +647,11 @@ export function PlanCreatePage() {
 
           {form.raceDate && dateTooLong && (
             <div className="rounded-lg border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/30 p-3 text-sm text-amber-800 dark:text-amber-300 text-center space-y-1">
-              <p className="font-semibold">
+              <p className="font-semibold flex items-center justify-center gap-1.5">
+                <AlertTriangle className="size-4 shrink-0" />
                 {isEn
-                  ? `⚠️ ${weeksCount} weeks is a long cycle`
-                  : `⚠️ ${weeksCount} semaines, c'est un cycle long`}
+                  ? `${weeksCount} weeks is a long cycle`
+                  : `${weeksCount} semaines, c'est un cycle long`}
               </p>
               <p className="text-xs">
                 {isEn

--- a/src/pages/PlanViewPage.tsx
+++ b/src/pages/PlanViewPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { usePageHint } from "@/hooks/usePageHint";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate, useLocation, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   ArrowLeft,
@@ -93,8 +93,12 @@ export function PlanViewPage() {
   usePageHint("plan-calendar", "hints.planCalendar.title", "hints.planCalendar.description");
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { i18n } = useTranslation("plan");
   const isEn = i18n.language?.startsWith("en") ?? false;
+
+  // Read weekNumber from navigation state (returned from workout detail page)
+  const returnedWeek = (location.state as { returnToWeek?: number } | null)?.returnToWeek;
 
   const { plan, isLoading, reload: reloadPlan } = usePlan(id);
   const { planViewMode, setPlanViewMode } = usePlanViewMode();
@@ -380,10 +384,20 @@ export function PlanViewPage() {
     runAdaptationIfReady(weekNumber, true);
   }, [plan, reloadPlan, runAdaptationIfReady]);
 
-  const handleSessionClick = useCallback((_weekNumber: number, _sessionIndex: number, workoutId: string) => {
+  const handleSessionClick = useCallback((weekNumber: number, sessionIndex: number, workoutId: string) => {
     if (workoutId && workoutId !== "__race_day__" && !workoutId.startsWith("__activity_")) {
+      // Find the session to pass volume info for scaled duration display (#32)
+      const week = plan?.weeks.find((w) => w.weekNumber === weekNumber);
+      const session = week?.sessions[sessionIndex];
       navigate(`/workout/${workoutId}`, {
-        state: { from: "plan", planId: plan?.id, planName: plan ? (isEn ? plan.nameEn : plan.name) : "" },
+        state: {
+          from: "plan",
+          planId: plan?.id,
+          planName: plan ? (isEn ? plan.nameEn : plan.name) : "",
+          weekNumber,
+          volumePercent: week?.volumePercent,
+          estimatedDurationMin: session?.estimatedDurationMin,
+        },
       });
     }
   }, [plan, isEn, navigate]);
@@ -746,6 +760,7 @@ export function PlanViewPage() {
                 plan={plan}
                 workoutNames={workoutNames}
                 currentWeek={currentWeek}
+                initialWeek={returnedWeek}
                 isEn={isEn}
                 onSessionClick={handleSessionClick}
                 onSessionMove={handleSessionMove}

--- a/src/pages/PlanViewPage.tsx
+++ b/src/pages/PlanViewPage.tsx
@@ -97,8 +97,19 @@ export function PlanViewPage() {
   const { i18n } = useTranslation("plan");
   const isEn = i18n.language?.startsWith("en") ?? false;
 
-  // Read weekNumber from navigation state (returned from workout detail page)
-  const returnedWeek = (location.state as { returnToWeek?: number } | null)?.returnToWeek;
+  // Read return state from navigation (coming back from workout detail page)
+  const returnState = location.state as { returnToWeek?: number; returnScrollY?: number } | null;
+  const returnedWeek = returnState?.returnToWeek;
+
+  // Restore scroll position when returning from workout detail
+  useEffect(() => {
+    if (returnState?.returnScrollY != null) {
+      // Defer to allow the page to render first
+      requestAnimationFrame(() => {
+        window.scrollTo(0, returnState.returnScrollY!);
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { plan, isLoading, reload: reloadPlan } = usePlan(id);
   const { planViewMode, setPlanViewMode } = usePlanViewMode();
@@ -397,6 +408,7 @@ export function PlanViewPage() {
           weekNumber,
           volumePercent: week?.volumePercent,
           estimatedDurationMin: session?.estimatedDurationMin,
+          scrollY: window.scrollY,
         },
       });
     }

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -74,12 +74,13 @@ export function WorkoutDetailPage() {
     weekNumber?: number;
     volumePercent?: number;
     estimatedDurationMin?: number;
+    scrollY?: number;
   } | null;
   const backTo = locationState?.from === "plan" && locationState.planId
     ? {
         path: `/plan/${locationState.planId}`,
         label: isEn ? `Back to ${locationState.planName || "plan"}` : `Retour au plan`,
-        state: { returnToWeek: locationState.weekNumber },
+        state: { returnToWeek: locationState.weekNumber, returnScrollY: locationState.scrollY },
       }
     : { path: "/library", label: t("common:actions.backToLibrary"), state: undefined };
 

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -222,11 +222,9 @@ export function WorkoutDetailPage() {
           <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-2.5 text-sm flex items-center gap-2">
             <Clock className="size-4 text-primary shrink-0" />
             <span>
-              {isEn
-                ? `In your plan (week ${planWeekNumber}, ${planVolumePercent}% volume): ~${Math.round(planEstimatedDuration)} min`
-                : `Dans votre plan (semaine ${planWeekNumber}, ${planVolumePercent}% volume) : ~${Math.round(planEstimatedDuration)} min`}
+              {t("session:planContext.banner", { week: planWeekNumber, volume: planVolumePercent, duration: Math.round(planEstimatedDuration) })}
               <span className="text-muted-foreground ml-1">
-                {isEn ? `(full session: ${duration} min)` : `(séance complète : ${duration} min)`}
+                {t("session:planContext.fullSession", { duration })}
               </span>
             </span>
           </div>

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -43,7 +43,6 @@ import { useWorkout, useRelatedWorkouts, useTips } from "@/hooks";
 import type { WorkoutCategory, ZoneRange } from "@/types";
 import {
   getDominantZone,
-  DIFFICULTY_META,
 } from "@/types";
 import { loadUserZonePrefs, calculateAllZones } from "@/lib/zones";
 
@@ -133,7 +132,13 @@ export function WorkoutDetailPage() {
   }
 
   const dominantZone = getDominantZone(workout);
-  const sessionData = transformSessionBlocks(
+  // Plan context: scaled duration when coming from a plan
+  const planVolumePercent = locationState?.volumePercent;
+  const planWeekNumber = locationState?.weekNumber;
+  const hasPlanContext = locationState?.from === "plan" && planVolumePercent != null && planVolumePercent !== 100;
+
+  // Base (unscaled) session data
+  const baseSessionData = transformSessionBlocks(
     {
       warmup: workout.warmupTemplate,
       mainSet: workout.mainSetTemplate,
@@ -141,16 +146,23 @@ export function WorkoutDetailPage() {
     },
     isEn
   );
-  const duration = Math.round(sessionData.totalDurationMin);
-  const CategoryIcon = CATEGORY_ICONS[workout.category];
-  void DIFFICULTY_META[workout.difficulty];
+  const baseDuration = Math.round(baseSessionData.totalDurationMin);
 
-  // Plan context: scaled duration when coming from a plan
-  const planVolumePercent = locationState?.volumePercent;
-  const planEstimatedDuration = locationState?.estimatedDurationMin;
-  const planWeekNumber = locationState?.weekNumber;
-  const hasPlanContext = locationState?.from === "plan" && planEstimatedDuration && planEstimatedDuration !== duration;
-  const displayDuration = hasPlanContext ? Math.round(planEstimatedDuration) : duration;
+  // Scaled session data when coming from a plan
+  const sessionData = hasPlanContext
+    ? transformSessionBlocks(
+        {
+          warmup: workout.warmupTemplate,
+          mainSet: workout.mainSetTemplate,
+          cooldown: workout.cooldownTemplate,
+        },
+        isEn,
+        planVolumePercent
+      )
+    : baseSessionData;
+  const duration = Math.round(sessionData.totalDurationMin);
+
+  const CategoryIcon = CATEGORY_ICONS[workout.category];
 
   // Environment requirements
   const envRequirements: { icon: React.ComponentType<{ className?: string }>; text: string }[] = [];
@@ -222,9 +234,9 @@ export function WorkoutDetailPage() {
           <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-2.5 text-sm flex items-center gap-2">
             <Clock className="size-4 text-primary shrink-0" />
             <span>
-              {t("session:planContext.banner", { week: planWeekNumber, volume: planVolumePercent, duration: Math.round(planEstimatedDuration) })}
+              {t("session:planContext.banner", { week: planWeekNumber, volume: planVolumePercent, duration })}
               <span className="text-muted-foreground ml-1">
-                {t("session:planContext.fullSession", { duration })}
+                {t("session:planContext.fullSession", { duration: baseDuration })}
               </span>
             </span>
           </div>
@@ -274,10 +286,10 @@ export function WorkoutDetailPage() {
             <div className="grid grid-cols-2 gap-2 lg:gap-4">
               <div className="bg-muted/50 border rounded-lg lg:rounded-xl p-4 lg:p-6 flex flex-col items-center justify-center text-center">
                 <Clock className="size-4 lg:size-5 text-muted-foreground mb-1 lg:mb-2" />
-                <span className="text-lg lg:text-2xl font-bold">{displayDuration}</span>
+                <span className="text-lg lg:text-2xl font-bold">{duration}</span>
                 <span className="text-[10px] lg:text-xs text-muted-foreground">{t("common:units.minutes")}</span>
                 {hasPlanContext && (
-                  <span className="text-[9px] text-muted-foreground line-through">{duration}</span>
+                  <span className="text-[9px] text-muted-foreground line-through">{baseDuration}</span>
                 )}
               </div>
               <div className="bg-muted/50 border rounded-lg lg:rounded-xl p-4 lg:p-6 flex flex-col items-center justify-center text-center">
@@ -315,7 +327,7 @@ export function WorkoutDetailPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <SessionTimeline workout={workout} />
+                <SessionTimeline workout={workout} volumePercent={hasPlanContext ? planVolumePercent : undefined} />
               </CardContent>
             </Card>
 
@@ -327,7 +339,7 @@ export function WorkoutDetailPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <WorkoutStructure workout={workout} userZones={hasUserZones ? userZones : undefined} />
+                <WorkoutStructure workout={workout} userZones={hasUserZones ? userZones : undefined} volumePercent={hasPlanContext ? planVolumePercent : undefined} />
               </CardContent>
             </Card>
 
@@ -357,7 +369,7 @@ export function WorkoutDetailPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <ZoneDistribution workout={workout} />
+                <ZoneDistribution workout={workout} volumePercent={hasPlanContext ? planVolumePercent : undefined} />
               </CardContent>
             </Card>
 

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -68,10 +68,21 @@ export function WorkoutDetailPage() {
   const { t, i18n } = useTranslation(["session", "library", "common"]);
   const isEn = i18n.language?.startsWith("en") ?? false;
 
-  const locationState = location.state as { from?: string; planId?: string; planName?: string } | null;
+  const locationState = location.state as {
+    from?: string;
+    planId?: string;
+    planName?: string;
+    weekNumber?: number;
+    volumePercent?: number;
+    estimatedDurationMin?: number;
+  } | null;
   const backTo = locationState?.from === "plan" && locationState.planId
-    ? { path: `/plan/${locationState.planId}`, label: isEn ? `Back to ${locationState.planName || "plan"}` : `Retour au plan` }
-    : { path: "/library", label: t("common:actions.backToLibrary") };
+    ? {
+        path: `/plan/${locationState.planId}`,
+        label: isEn ? `Back to ${locationState.planName || "plan"}` : `Retour au plan`,
+        state: { returnToWeek: locationState.weekNumber },
+      }
+    : { path: "/library", label: t("common:actions.backToLibrary"), state: undefined };
 
   const { workout, isLoading } = useWorkout(id);
   const { workouts: relatedWorkouts } = useRelatedWorkouts(workout);
@@ -112,7 +123,7 @@ export function WorkoutDetailPage() {
       <div className="py-12 text-center">
         <p className="text-muted-foreground">{t("common:errors.workoutNotFound")}</p>
         <Button variant="link" asChild className="mt-4">
-          <Link to={backTo.path}>
+          <Link to={backTo.path} state={backTo.state}>
             <ArrowLeft className="mr-2 size-4" />
             {backTo.label}
           </Link>
@@ -133,6 +144,13 @@ export function WorkoutDetailPage() {
   const duration = Math.round(sessionData.totalDurationMin);
   const CategoryIcon = CATEGORY_ICONS[workout.category];
   void DIFFICULTY_META[workout.difficulty];
+
+  // Plan context: scaled duration when coming from a plan
+  const planVolumePercent = locationState?.volumePercent;
+  const planEstimatedDuration = locationState?.estimatedDurationMin;
+  const planWeekNumber = locationState?.weekNumber;
+  const hasPlanContext = locationState?.from === "plan" && planEstimatedDuration && planEstimatedDuration !== duration;
+  const displayDuration = hasPlanContext ? Math.round(planEstimatedDuration) : duration;
 
   // Environment requirements
   const envRequirements: { icon: React.ComponentType<{ className?: string }>; text: string }[] = [];
@@ -193,11 +211,26 @@ export function WorkoutDetailPage() {
       <div className={`zone-${dominantZone} py-8 space-y-8`}>
         {/* Back Button */}
         <Button variant="ghost" size="sm" asChild>
-          <Link to={backTo.path}>
+          <Link to={backTo.path} state={backTo.state}>
             <ArrowLeft className="mr-2 size-4" />
             {backTo.label}
           </Link>
         </Button>
+
+        {/* Plan context banner */}
+        {hasPlanContext && (
+          <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-2.5 text-sm flex items-center gap-2">
+            <Clock className="size-4 text-primary shrink-0" />
+            <span>
+              {isEn
+                ? `In your plan (week ${planWeekNumber}, ${planVolumePercent}% volume): ~${Math.round(planEstimatedDuration)} min`
+                : `Dans votre plan (semaine ${planWeekNumber}, ${planVolumePercent}% volume) : ~${Math.round(planEstimatedDuration)} min`}
+              <span className="text-muted-foreground ml-1">
+                {isEn ? `(full session: ${duration} min)` : `(séance complète : ${duration} min)`}
+              </span>
+            </span>
+          </div>
+        )}
 
         {/* Bento Header */}
         <header className="grid grid-cols-1 lg:grid-cols-12 gap-6">
@@ -243,8 +276,11 @@ export function WorkoutDetailPage() {
             <div className="grid grid-cols-2 gap-2 lg:gap-4">
               <div className="bg-muted/50 border rounded-lg lg:rounded-xl p-4 lg:p-6 flex flex-col items-center justify-center text-center">
                 <Clock className="size-4 lg:size-5 text-muted-foreground mb-1 lg:mb-2" />
-                <span className="text-lg lg:text-2xl font-bold">{duration}</span>
+                <span className="text-lg lg:text-2xl font-bold">{displayDuration}</span>
                 <span className="text-[10px] lg:text-xs text-muted-foreground">{t("common:units.minutes")}</span>
+                {hasPlanContext && (
+                  <span className="text-[9px] text-muted-foreground line-through">{duration}</span>
+                )}
               </div>
               <div className="bg-muted/50 border rounded-lg lg:rounded-xl p-4 lg:p-6 flex flex-col items-center justify-center text-center">
                 <Dumbbell className="size-4 lg:size-5 text-muted-foreground mb-1 lg:mb-2" />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -307,12 +307,12 @@ export const CATEGORY_META: Record<
 // Difficulty Display Metadata
 export const DIFFICULTY_META: Record<
   Difficulty,
-  { label: string; labelEn: string; level: number }
+  { label: string; labelEn: string; level: number; desc: string; descEn: string }
 > = {
-  beginner: { label: "Débutant", labelEn: "Beginner", level: 1 },
-  intermediate: { label: "Intermédiaire", labelEn: "Intermediate", level: 2 },
-  advanced: { label: "Avancé", labelEn: "Advanced", level: 3 },
-  elite: { label: "Élite", labelEn: "Elite", level: 4 },
+  beginner: { label: "Débutant", labelEn: "Beginner", level: 1, desc: "1 à 2 sorties/semaine · moins de 15 km/semaine", descEn: "1–2 runs/week · less than 15 km/week" },
+  intermediate: { label: "Intermédiaire", labelEn: "Intermediate", level: 2, desc: "3 à 4 sorties/semaine · 20–40 km/semaine", descEn: "3–4 runs/week · 20–40 km/week" },
+  advanced: { label: "Avancé", labelEn: "Advanced", level: 3, desc: "4 à 5 sorties/semaine · 40–70 km/semaine", descEn: "4–5 runs/week · 40–70 km/week" },
+  elite: { label: "Élite", labelEn: "Elite", level: 4, desc: "5 à 7 sorties/semaine · 70+ km/semaine", descEn: "5–7 runs/week · 70+ km/week" },
 };
 
 // Helper to extract zone number from zone string


### PR DESCRIPTION
- #27: Redesign plan duration warning with specific risks and suggestions
- #28: Add concrete frequency/volume descriptions to all difficulty levels
- #29: Add finish time input mode (toggle pace/time) in plan creation
- #30: Rename and clarify distance vs volume stats with descriptive subtitles
- #31: Preserve week position when navigating back from workout detail to plan
- #32: Show plan-scaled duration on workout detail page with context banner

Updates FR/EN translations and changelog for v0.3.2.

https://claude.ai/code/session_01Ea38PUBoaa6Pm7BzTobKkt