### PR TITLE
Refactor plan export & add inline plan name editing

### DIFF
--- a/src/components/domain/PlanExportMenu.tsx
+++ b/src/components/domain/PlanExportMenu.tsx
@@ -1,0 +1,161 @@
+import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Download, Calendar, FileText, Loader2 } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { exportPlanToICS, exportPlanToPDF } from "@/lib/export";
+import { getWorkoutById } from "@/data/workouts";
+import { toast } from "sonner";
+import type { TrainingPlan } from "@/types/plan";
+import type { WorkoutTemplate } from "@/types";
+
+interface PlanExportMenuProps {
+  plan: TrainingPlan;
+  /** Pre-loaded workout names (optional — loaded on demand if absent) */
+  workoutNames?: Record<string, string>;
+  /** Pre-loaded workout templates (optional — loaded on demand if absent) */
+  workoutTemplates?: Record<string, WorkoutTemplate>;
+  isEn: boolean;
+  size?: "sm" | "default";
+  /** Called when ICS export needs user to pick training days (list mode) */
+  onIcsDialogOpen?: () => void;
+  /** When provided, used to determine if days are already assigned (non-list mode) */
+  planViewMode?: string;
+}
+
+/**
+ * Collects all unique workout IDs from a plan and resolves names + templates.
+ */
+function resolvePlanWorkouts(plan: TrainingPlan, isEn: boolean) {
+  const names: Record<string, string> = {};
+  const templates: Record<string, WorkoutTemplate> = {};
+
+  const ids = new Set<string>();
+  for (const week of plan.weeks) {
+    for (const session of week.sessions) {
+      if (session.workoutId && !session.workoutId.startsWith("__")) {
+        ids.add(session.workoutId);
+      }
+    }
+  }
+
+  for (const id of ids) {
+    const w = getWorkoutById(id);
+    if (w) {
+      names[id] = isEn ? (w.nameEn || w.name) : w.name;
+      templates[id] = w;
+    }
+  }
+
+  return { names, templates };
+}
+
+export function PlanExportMenu({
+  plan,
+  workoutNames: preloadedNames,
+  workoutTemplates: preloadedTemplates,
+  isEn,
+  size = "default",
+  onIcsDialogOpen,
+  planViewMode,
+}: PlanExportMenuProps) {
+  const { t } = useTranslation("common");
+  const [isExporting, setIsExporting] = useState(false);
+
+  const getWorkoutData = useCallback(() => {
+    if (preloadedNames && preloadedTemplates && Object.keys(preloadedNames).length > 0) {
+      return { names: preloadedNames, templates: preloadedTemplates };
+    }
+    return resolvePlanWorkouts(plan, isEn);
+  }, [plan, isEn, preloadedNames, preloadedTemplates]);
+
+  const handleExportPDF = useCallback(async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      const { names, templates } = getWorkoutData();
+      await exportPlanToPDF(plan, names, templates, isEn);
+      toast.success(t("export.success.pdf"));
+    } catch {
+      toast.error(t("export.error.pdf"));
+    } finally {
+      setIsExporting(false);
+    }
+  }, [plan, isEn, isExporting, getWorkoutData, t]);
+
+  const handleExportICS = useCallback(() => {
+    // If days are already assigned (calendar/weekly/monthly mode), export directly
+    if (planViewMode && planViewMode !== "list") {
+      const usedDays = [...new Set(plan.weeks.flatMap(w => w.sessions.map(s => s.dayOfWeek)))].sort();
+      const longRunDay = plan.config.longRunDay ?? 6;
+      setIsExporting(true);
+      try {
+        const { names, templates } = getWorkoutData();
+        exportPlanToICS(plan, names, templates, isEn, usedDays, longRunDay);
+        toast.success(t("export.success.calendar"));
+      } catch {
+        toast.error(t("export.error.calendar"));
+      } finally {
+        setIsExporting(false);
+      }
+      return;
+    }
+    // Otherwise open the dialog for day selection
+    onIcsDialogOpen?.();
+  }, [plan, isEn, planViewMode, onIcsDialogOpen, getWorkoutData, t, isExporting]);
+
+  const handleExportJSON = useCallback(() => {
+    const json = JSON.stringify(plan, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `plan-${plan.name || plan.id}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success(isEn ? "Plan exported" : "Plan exporté");
+  }, [plan, isEn]);
+
+  const isSmall = size === "sm";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant={isSmall ? "outline" : "default"}
+          size={isSmall ? "sm" : "default"}
+          disabled={isExporting}
+          className={isSmall ? "rounded-full" : "rounded-full px-5 py-2.5 h-auto font-bold"}
+        >
+          {isExporting ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Download className="size-4" />
+          )}
+          <span className={isSmall ? "hidden sm:inline ml-1" : "ml-2"}>
+            {t("export.title")}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuItem onClick={handleExportPDF}>
+          <FileText className="size-4" />
+          {t("export.pdf")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleExportICS}>
+          <Calendar className="size-4" />
+          {t("export.calendar")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleExportJSON}>
+          <Download className="size-4" />
+          {t("export.json")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/domain/PlanExportMenu.tsx
+++ b/src/components/domain/PlanExportMenu.tsx
@@ -127,10 +127,10 @@ export function PlanExportMenu({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          variant={isSmall ? "outline" : "default"}
+          variant="default"
           size={isSmall ? "sm" : "default"}
           disabled={isExporting}
-          className={isSmall ? "rounded-full" : "rounded-full px-5 py-2.5 h-auto font-bold"}
+          className={isSmall ? "rounded-full font-semibold" : "rounded-full px-5 py-2.5 h-auto font-bold"}
         >
           {isExporting ? (
             <Loader2 className="size-4 animate-spin" />

--- a/src/components/domain/PlanExportMenu.tsx
+++ b/src/components/domain/PlanExportMenu.tsx
@@ -31,7 +31,7 @@ interface PlanExportMenuProps {
 /**
  * Collects all unique workout IDs from a plan and resolves names + templates.
  */
-function resolvePlanWorkouts(plan: TrainingPlan, isEn: boolean) {
+async function resolvePlanWorkouts(plan: TrainingPlan, isEn: boolean) {
   const names: Record<string, string> = {};
   const templates: Record<string, WorkoutTemplate> = {};
 
@@ -45,7 +45,7 @@ function resolvePlanWorkouts(plan: TrainingPlan, isEn: boolean) {
   }
 
   for (const id of ids) {
-    const w = getWorkoutById(id);
+    const w = await getWorkoutById(id);
     if (w) {
       names[id] = isEn ? (w.nameEn || w.name) : w.name;
       templates[id] = w;
@@ -67,7 +67,7 @@ export function PlanExportMenu({
   const { t } = useTranslation("common");
   const [isExporting, setIsExporting] = useState(false);
 
-  const getWorkoutData = useCallback(() => {
+  const getWorkoutData = useCallback(async () => {
     if (preloadedNames && preloadedTemplates && Object.keys(preloadedNames).length > 0) {
       return { names: preloadedNames, templates: preloadedTemplates };
     }
@@ -78,7 +78,7 @@ export function PlanExportMenu({
     if (isExporting) return;
     setIsExporting(true);
     try {
-      const { names, templates } = getWorkoutData();
+      const { names, templates } = await getWorkoutData();
       await exportPlanToPDF(plan, names, templates, isEn);
       toast.success(t("export.success.pdf"));
     } catch {
@@ -88,14 +88,14 @@ export function PlanExportMenu({
     }
   }, [plan, isEn, isExporting, getWorkoutData, t]);
 
-  const handleExportICS = useCallback(() => {
+  const handleExportICS = useCallback(async () => {
     // If days are already assigned (calendar/weekly/monthly mode), export directly
     if (planViewMode && planViewMode !== "list") {
       const usedDays = [...new Set(plan.weeks.flatMap(w => w.sessions.map(s => s.dayOfWeek)))].sort();
       const longRunDay = plan.config.longRunDay ?? 6;
       setIsExporting(true);
       try {
-        const { names, templates } = getWorkoutData();
+        const { names, templates } = await getWorkoutData();
         exportPlanToICS(plan, names, templates, isEn, usedDays, longRunDay);
         toast.success(t("export.success.calendar"));
       } catch {

--- a/src/components/domain/PlanExportMenu.tsx
+++ b/src/components/domain/PlanExportMenu.tsx
@@ -137,7 +137,7 @@ export function PlanExportMenu({
           ) : (
             <Download className="size-4" />
           )}
-          <span className={isSmall ? "hidden sm:inline ml-1" : "ml-2"}>
+          <span className={isSmall ? "ml-1" : "ml-2"}>
             {t("export.title")}
           </span>
         </Button>

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -46,6 +46,7 @@
     "calendar": "Calendar (ICS)",
     "image": "Image (PNG)",
     "pdf": "Document (PDF)",
+    "json": "Data (JSON)",
     "garmin": "Garmin (FIT)",
     "selectDateTime": "Select date and time",
     "download": "Download",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -46,6 +46,7 @@
     "calendar": "Calendrier (ICS)",
     "image": "Image (PNG)",
     "pdf": "Document (PDF)",
+    "json": "Donn\u00e9es (JSON)",
     "garmin": "Garmin (FIT)",
     "selectDateTime": "Choisir date et heure",
     "download": "Télécharger",

--- a/src/lib/planUtils.ts
+++ b/src/lib/planUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared plan utilities.
+ *
+ * getCurrentWeek parses the date string as local midnight to avoid
+ * UTC/local timezone mismatches that could shift the result by one day
+ * (and therefore one week) near week boundaries.
+ */
+
+export function getCurrentWeek(dateStr: string): number {
+  // Parse as local date components to avoid UTC offset issues
+  const dateOnly = dateStr.split("T")[0];
+  const [y, m, d] = dateOnly.split("-").map(Number);
+  const start = new Date(y, m - 1, d); // local midnight
+
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()); // local midnight
+
+  const diffMs = today.getTime() - start.getTime();
+  // Math.round absorbs potential DST transitions (±1 h)
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+  return Math.floor(diffDays / 7) + 1;
+}

--- a/src/pages/PlanViewPage.tsx
+++ b/src/pages/PlanViewPage.tsx
@@ -591,9 +591,9 @@ export function PlanViewPage() {
               onIcsDialogOpen={() => setShowIcsDialog(true)}
             />
             <Button
-              variant="outline"
+              variant="destructive"
               size="sm"
-              className="rounded-full text-destructive hover:text-destructive"
+              className="rounded-full"
               onClick={() => setShowDeleteDialog(true)}
               title={isEn ? "Delete plan" : "Supprimer le plan"}
             >

--- a/src/pages/PlanViewPage.tsx
+++ b/src/pages/PlanViewPage.tsx
@@ -12,10 +12,9 @@ import {
   Flag,
   ChevronDown,
   ChevronUp,
-  Download,
   Plus,
-  MoreHorizontal,
   Pencil,
+  AlertTriangle,
 } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -29,19 +28,13 @@ import {
   DialogFooter,
   DialogClose,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { SEOHead } from "@/components/seo";
 import { cn } from "@/lib/utils";
 import { usePlan } from "@/hooks/usePlans";
 import { deletePlan, getPlan, savePlan, updatePlanSession, moveSession, deleteSessionFromPlan, addSessionToPlan, updateSessionCompletion } from "@/lib/planStorage";
 import { adaptPlan } from "@/lib/planGenerator/adapt";
 import { getWorkoutById } from "@/data/workouts";
-import { exportPlanToICS, exportPlanToPDF } from "@/lib/export";
+import { exportPlanToICS } from "@/lib/export";
 import { computeWeekKm, computeWeekDuration } from "@/lib/planStats";
 import { PlanStatsSection } from "@/components/domain/PlanStatsSection";
 import {
@@ -57,7 +50,9 @@ import { PlanWeeklyView } from "@/components/domain/PlanWeeklyView";
 import { PlanMonthlyView } from "@/components/domain/PlanMonthlyView";
 import { PlanWorkoutPanel } from "@/components/domain/PlanWorkoutPanel";
 import { PlanViewModeSelector } from "@/components/domain/PlanViewModeSelector";
+import { PlanExportMenu } from "@/components/domain/PlanExportMenu";
 import { usePlanViewMode } from "@/hooks/usePlanViewMode";
+import { getCurrentWeek } from "@/lib/planUtils";
 
 const SESSION_TYPE_LABELS: Record<string, { fr: string; en: string }> = {
   recovery: { fr: "Récupération", en: "Recovery" },
@@ -79,14 +74,6 @@ function formatDate(isoDate: string, isEn: boolean): string {
     month: "short",
     year: "numeric",
   });
-}
-
-function getCurrentWeek(createdAt: string): number {
-  const start = new Date(createdAt);
-  const now = new Date();
-  const diffMs = now.getTime() - start.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  return Math.floor(diffDays / 7) + 1;
 }
 
 export function PlanViewPage() {
@@ -138,6 +125,8 @@ export function PlanViewPage() {
   const [showDateDialog, setShowDateDialog] = useState(false);
   const [editStartDate, setEditStartDate] = useState("");
   const [rpePrompt, setRpePrompt] = useState<{ weekNumber: number; sessionIndex: number } | null>(null);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [editName, setEditName] = useState("");
 
   const currentWeek = useMemo(() => {
     if (!plan) return 0;
@@ -252,32 +241,6 @@ export function PlanViewPage() {
       setIsExporting(false);
     }
   }, [plan, workoutNames, workoutTemplates, isEn, isExporting]);
-
-  const handleExportPDF = useCallback(async () => {
-    if (!plan || isExporting) return;
-    setIsExporting(true);
-    try {
-      await exportPlanToPDF(plan, workoutNames, workoutTemplates, isEn);
-      toast.success(isEn ? "PDF exported" : "PDF exporté");
-    } catch {
-      toast.error(isEn ? "Export failed" : "Échec de l'export");
-    } finally {
-      setIsExporting(false);
-    }
-  }, [plan, workoutNames, workoutTemplates, isEn, isExporting]);
-
-  const handleExportPlanJSON = useCallback(() => {
-    if (!plan) return;
-    const json = JSON.stringify(plan, null, 2);
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `plan-${plan.name || plan.id}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
-    toast.success(isEn ? "Plan exported" : "Plan export\u00e9");
-  }, [plan, isEn]);
 
   const handleSwapSession = useCallback((workout: WorkoutTemplate) => {
     if (!plan || !swapTarget) return;
@@ -492,9 +455,9 @@ export function PlanViewPage() {
 
   const isFreePlan = plan.config.planMode === "free";
   const raceMeta = plan.config.raceDistance ? RACE_DISTANCE_META[plan.config.raceDistance] : null;
-  const planName = isFreePlan
-    ? (plan.config.planName || plan.name)
-    : (isEn ? plan.nameEn : plan.name);
+  const planName = plan.config.planName || (isFreePlan
+    ? plan.name
+    : (isEn ? plan.nameEn : plan.name));
   const raceDate = plan.config.raceDate;
 
   return (
@@ -516,7 +479,37 @@ export function PlanViewPage() {
         {/* Header Section */}
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-3">
-            <h1 className="text-3xl font-bold">{planName}</h1>
+            {isEditingName ? (
+              <input
+                autoFocus
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                onBlur={() => {
+                  const trimmed = editName.trim();
+                  if (trimmed && trimmed !== planName) {
+                    plan.config.planName = trimmed;
+                    savePlan(plan);
+                    reloadPlan();
+                    toast.success(isEn ? "Name updated" : "Nom mis à jour");
+                  }
+                  setIsEditingName(false);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") e.currentTarget.blur();
+                  if (e.key === "Escape") setIsEditingName(false);
+                }}
+                className="text-3xl font-bold bg-transparent border-b-2 border-primary outline-none w-full"
+              />
+            ) : (
+              <h1
+                className="text-3xl font-bold cursor-pointer group flex items-center gap-2"
+                onClick={() => { setEditName(planName); setIsEditingName(true); }}
+                title={isEn ? "Click to rename" : "Cliquer pour renommer"}
+              >
+                {planName}
+                <Pencil className="size-4 opacity-0 group-hover:opacity-50 transition-opacity" />
+              </h1>
+            )}
             <div className="flex flex-wrap items-center gap-2">
               {raceMeta && (
                 <Badge variant="default">
@@ -587,26 +580,26 @@ export function PlanViewPage() {
               )}
             </div>
           </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="rounded-full">
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleExportPlanJSON}>
-                <Download className="size-4" />
-                {isEn ? "Export plan (JSON)" : "Exporter le plan (JSON)"}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setShowDeleteDialog(true)}
-                className="text-destructive focus:text-destructive"
-              >
-                <Trash2 className="size-4" />
-                {isEn ? "Delete plan" : "Supprimer le plan"}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center gap-2">
+            <PlanExportMenu
+              plan={plan}
+              workoutNames={workoutNames}
+              workoutTemplates={workoutTemplates}
+              isEn={isEn}
+              size="sm"
+              planViewMode={planViewMode}
+              onIcsDialogOpen={() => setShowIcsDialog(true)}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="rounded-full text-destructive hover:text-destructive"
+              onClick={() => setShowDeleteDialog(true)}
+              title={isEn ? "Delete plan" : "Supprimer le plan"}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
         </div>
 
         {/* Phase Timeline */}
@@ -680,29 +673,7 @@ export function PlanViewPage() {
               <Plus className="size-4" />
               <span className="ml-1">{isEn ? "Add workout" : "Ajouter une séance"}</span>
             </Button>
-          <PlanViewModeSelector value={planViewMode} onChange={setPlanViewMode} />
-          <Button variant="outline" size="sm" onClick={handleExportPDF} disabled={isExporting} className="rounded-full">
-            {isExporting ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
-            <span className="hidden sm:inline ml-1">{isEn ? "PDF" : "PDF"}</span>
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={isExporting}
-            className="rounded-full"
-            onClick={() => {
-              if (planViewMode !== "list" && plan) {
-                // In calendar/weekly/monthly mode, days are already assigned -- export directly
-                const usedDays = [...new Set(plan.weeks.flatMap(w => w.sessions.map(s => s.dayOfWeek)))].sort();
-                handleIcsExport(usedDays, plan.config.longRunDay ?? 6);
-              } else {
-                setShowIcsDialog(true);
-              }
-            }}
-          >
-            <Calendar className="size-4" />
-            <span className="hidden sm:inline ml-1">{isEn ? "ICS" : "ICS"}</span>
-          </Button>
+            <PlanViewModeSelector value={planViewMode} onChange={setPlanViewMode} />
           </div>
         </div>
 
@@ -1238,16 +1209,71 @@ export function PlanViewPage() {
                   className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                 />
               </div>
-              {editStartDate && (
-                <p className="text-sm text-muted-foreground">
-                  {isEn ? "End date" : "Date de fin"} :{" "}
-                  {(() => {
-                    const d = new Date(editStartDate);
-                    d.setDate(d.getDate() + plan.totalWeeks * 7);
-                    return d.toLocaleDateString(isEn ? "en-US" : "fr-FR");
-                  })()}
-                </p>
-              )}
+
+              {/* Quick action: next Monday */}
+              {(() => {
+                const now = new Date();
+                const dayOfWeek = now.getDay();
+                const daysUntilMonday = dayOfWeek === 0 ? 1 : dayOfWeek === 1 ? 7 : 8 - dayOfWeek;
+                const nextMonday = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntilMonday);
+                const nextMondayStr = nextMonday.toISOString().split("T")[0];
+                return (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-muted-foreground"
+                    onClick={() => setEditStartDate(nextMondayStr)}
+                  >
+                    <Calendar className="size-3.5" />
+                    {isEn ? "Start next Monday" : "Commencer lundi prochain"}
+                    {" "}({nextMonday.toLocaleDateString(isEn ? "en-US" : "fr-FR", { day: "numeric", month: "short" })})
+                  </Button>
+                );
+              })()}
+
+              {/* Summary */}
+              {editStartDate && (() => {
+                const [y, m, d] = editStartDate.split("-").map(Number);
+                const startD = new Date(y, m - 1, d);
+                const endD = new Date(y, m - 1, d + plan.totalWeeks * 7);
+                const weekdayStr = startD.toLocaleDateString(isEn ? "en-US" : "fr-FR", { weekday: "long" });
+                const isPast = startD < new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
+
+                return (
+                  <div className="space-y-3 rounded-lg border bg-muted/30 p-3">
+                    <div className="space-y-1.5 text-sm">
+                      <div className="flex items-center gap-2">
+                        <Calendar className="size-4 text-muted-foreground shrink-0" />
+                        <span>
+                          {isEn ? "Start" : "D\u00e9but"} : {startD.toLocaleDateString(isEn ? "en-US" : "fr-FR", { day: "numeric", month: "long", year: "numeric" })}
+                          {" "}
+                          <span className="text-muted-foreground">({weekdayStr})</span>
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Flag className="size-4 text-muted-foreground shrink-0" />
+                        <span>
+                          {isEn ? "End" : "Fin"} : {endD.toLocaleDateString(isEn ? "en-US" : "fr-FR", { day: "numeric", month: "long", year: "numeric" })}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Clock className="size-4 text-muted-foreground shrink-0" />
+                        <span>{plan.totalWeeks} {isEn ? "weeks" : "semaines"}</span>
+                      </div>
+                    </div>
+                    {isPast && (
+                      <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
+                        <AlertTriangle className="size-4 shrink-0" />
+                        <span>
+                          {isEn
+                            ? "This date is in the past. The first weeks will already be elapsed."
+                            : "Cette date est dans le pass\u00e9. Les premi\u00e8res semaines seront d\u00e9j\u00e0 \u00e9coul\u00e9es."}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
             </div>
             <DialogFooter>
               <DialogClose asChild>
@@ -1258,8 +1284,8 @@ export function PlanViewPage() {
               <Button
                 onClick={() => {
                   if (editStartDate) {
-                    const endD = new Date(editStartDate);
-                    endD.setDate(endD.getDate() + plan.totalWeeks * 7);
+                    const [y, m, d] = editStartDate.split("-").map(Number);
+                    const endD = new Date(y, m - 1, d + plan.totalWeeks * 7);
                     plan.config.startDate = editStartDate;
                     plan.config.endDate = endD.toISOString().split("T")[0];
                   } else {

--- a/src/pages/PlansPage.tsx
+++ b/src/pages/PlansPage.tsx
@@ -213,9 +213,8 @@ function PlanCard({
           onIcsDialogOpen={() => onIcsDialogOpen(plan)}
         />
         <Button
-          variant="ghost"
+          variant="destructive"
           size="sm"
-          className="text-muted-foreground hover:text-destructive"
           onClick={(e) => {
             e.stopPropagation();
             onDelete(plan.id);

--- a/src/pages/PlansPage.tsx
+++ b/src/pages/PlansPage.tsx
@@ -39,6 +39,9 @@ import {
 } from "@/types/plan";
 import type { TrainingPlan, PhaseRange } from "@/types/plan";
 import type { TrainingPhase } from "@/types";
+import { getCurrentWeek } from "@/lib/planUtils";
+import { PlanExportMenu } from "@/components/domain/PlanExportMenu";
+import { IcsExportDialog } from "@/components/domain/IcsExportDialog";
 
 function formatDate(isoDate: string, isEn: boolean): string {
   const date = new Date(isoDate);
@@ -46,14 +49,6 @@ function formatDate(isoDate: string, isEn: boolean): string {
     day: "numeric",
     month: "short",
   });
-}
-
-function getCurrentWeek(createdAt: string): number {
-  const start = new Date(createdAt);
-  const now = new Date();
-  const diffMs = now.getTime() - start.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  return Math.floor(diffDays / 7) + 1;
 }
 
 function getCurrentPhase(
@@ -72,12 +67,12 @@ function PlanCard({
   plan,
   isEn,
   onDelete,
-  onExport,
+  onIcsDialogOpen,
 }: {
   plan: TrainingPlan;
   isEn: boolean;
   onDelete: (id: string) => void;
-  onExport: (plan: TrainingPlan) => void;
+  onIcsDialogOpen: (plan: TrainingPlan) => void;
 }) {
   const navigate = useNavigate();
   const isFreePlan = plan.config.planMode === "free";
@@ -211,18 +206,12 @@ function PlanCard({
             {isEn ? "View" : "Voir"}
           </Link>
         </Button>
-        <Button
-          variant="ghost"
+        <PlanExportMenu
+          plan={plan}
+          isEn={isEn}
           size="sm"
-          className="text-muted-foreground"
-          onClick={(e) => {
-            e.stopPropagation();
-            onExport(plan);
-          }}
-          title={isEn ? "Export JSON" : "Exporter JSON"}
-        >
-          <Download className="size-3.5" />
-        </Button>
+          onIcsDialogOpen={() => onIcsDialogOpen(plan)}
+        />
         <Button
           variant="ghost"
           size="sm"
@@ -245,6 +234,7 @@ export function PlansPage() {
   const navigate = useNavigate();
   const { plans, isLoading, remove, reload } = usePlans();
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [icsExportPlan, setIcsExportPlan] = useState<TrainingPlan | null>(null);
 
   const handleImport = useCallback(() => {
     const input = document.createElement("input");
@@ -347,17 +337,7 @@ export function PlansPage() {
                   plan={plan}
                   isEn={isEn}
                   onDelete={setDeleteTarget}
-                  onExport={(p) => {
-                    const json = JSON.stringify(p, null, 2);
-                    const blob = new Blob([json], { type: "application/json" });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement("a");
-                    a.href = url;
-                    a.download = `plan-${p.name || p.id}.json`;
-                    a.click();
-                    URL.revokeObjectURL(url);
-                    toast.success(isEn ? "Plan exported" : "Plan exporté");
-                  }}
+                  onIcsDialogOpen={setIcsExportPlan}
                 />
               ))}
             </div>
@@ -430,6 +410,37 @@ export function PlansPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* ICS Export Dialog (for plans without assigned days) */}
+      <IcsExportDialog
+        open={icsExportPlan !== null}
+        onOpenChange={(open) => !open && setIcsExportPlan(null)}
+        daysPerWeek={icsExportPlan?.config.daysPerWeek ?? 3}
+        onExport={(selectedDays, longRunDay) => {
+          if (!icsExportPlan) return;
+          import("@/lib/export").then(({ exportPlanToICS }) => {
+            import("@/data/workouts").then(({ getWorkoutById }) => {
+              const names: Record<string, string> = {};
+              const templates: Record<string, import("@/types").WorkoutTemplate> = {};
+              for (const week of icsExportPlan.weeks) {
+                for (const s of week.sessions) {
+                  if (s.workoutId && !s.workoutId.startsWith("__") && !names[s.workoutId]) {
+                    const w = getWorkoutById(s.workoutId);
+                    if (w) {
+                      names[s.workoutId] = isEn ? (w.nameEn || w.name) : w.name;
+                      templates[s.workoutId] = w;
+                    }
+                  }
+                }
+              }
+              exportPlanToICS(icsExportPlan, names, templates, isEn, selectedDays, longRunDay);
+              toast.success(isEn ? "Calendar exported" : "Calendrier exporté");
+            });
+          });
+          setIcsExportPlan(null);
+        }}
+        isEn={isEn}
+      />
     </>
   );
 }

--- a/src/pages/PlansPage.tsx
+++ b/src/pages/PlansPage.tsx
@@ -416,27 +416,25 @@ export function PlansPage() {
         open={icsExportPlan !== null}
         onOpenChange={(open) => !open && setIcsExportPlan(null)}
         daysPerWeek={icsExportPlan?.config.daysPerWeek ?? 3}
-        onExport={(selectedDays, longRunDay) => {
+        onExport={async (selectedDays, longRunDay) => {
           if (!icsExportPlan) return;
-          import("@/lib/export").then(({ exportPlanToICS }) => {
-            import("@/data/workouts").then(({ getWorkoutById }) => {
-              const names: Record<string, string> = {};
-              const templates: Record<string, import("@/types").WorkoutTemplate> = {};
-              for (const week of icsExportPlan.weeks) {
-                for (const s of week.sessions) {
-                  if (s.workoutId && !s.workoutId.startsWith("__") && !names[s.workoutId]) {
-                    const w = getWorkoutById(s.workoutId);
-                    if (w) {
-                      names[s.workoutId] = isEn ? (w.nameEn || w.name) : w.name;
-                      templates[s.workoutId] = w;
-                    }
-                  }
+          const { exportPlanToICS } = await import("@/lib/export");
+          const { getWorkoutById } = await import("@/data/workouts");
+          const names: Record<string, string> = {};
+          const templates: Record<string, import("@/types").WorkoutTemplate> = {};
+          for (const week of icsExportPlan.weeks) {
+            for (const s of week.sessions) {
+              if (s.workoutId && !s.workoutId.startsWith("__") && !names[s.workoutId]) {
+                const w = await getWorkoutById(s.workoutId);
+                if (w) {
+                  names[s.workoutId] = isEn ? (w.nameEn || w.name) : w.name;
+                  templates[s.workoutId] = w;
                 }
               }
-              exportPlanToICS(icsExportPlan, names, templates, isEn, selectedDays, longRunDay);
-              toast.success(isEn ? "Calendar exported" : "Calendrier exporté");
-            });
-          });
+            }
+          }
+          exportPlanToICS(icsExportPlan, names, templates, isEn, selectedDays, longRunDay);
+          toast.success(isEn ? "Calendar exported" : "Calendrier export\u00e9");
           setIcsExportPlan(null);
         }}
         isEn={isEn}


### PR DESCRIPTION
## Description

This PR refactors the plan export functionality and adds inline editing for plan names. Key changes:

### Export Refactoring
- **New `PlanExportMenu` component**: Extracted export logic (PDF, ICS, JSON) into a reusable dropdown menu component used in both `PlanViewPage` and `PlansPage`
- **Improved ICS export flow**: Automatically exports ICS with assigned days in calendar/weekly/monthly modes; falls back to day-selection dialog in list mode
- **Removed duplicate code**: Consolidated `handleExportPDF`, `handleExportICS`, and `handleExportJSON` handlers into the new component
- **Dynamic workout resolution**: Export menu resolves workout names and templates on-demand if not pre-loaded

### Plan Name Editing
- **Inline editing**: Click the plan name to edit it directly; changes are saved to `plan.config.planName`
- **Visual feedback**: Pencil icon appears on hover; input field with border-bottom styling
- **Keyboard support**: Enter to save, Escape to cancel, blur to confirm

### Utilities
- **New `planUtils.ts`**: Extracted `getCurrentWeek()` function to shared utility (used in both `PlanViewPage` and `PlansPage`)
- **Improved date handling**: `getCurrentWeek()` now parses dates as local midnight to avoid UTC/timezone edge cases near week boundaries

### Start Date Dialog Enhancement
- **Quick action button**: "Start next Monday" button for convenience
- **Rich summary display**: Shows start date, end date, duration, and warns if date is in the past
- **Better UX**: Improved date calculations and visual layout with icons

### UI/UX Improvements
- Removed separate PDF/ICS buttons from toolbar; consolidated into `PlanExportMenu`
- Removed `MoreHorizontal` dropdown; delete button now standalone
- Updated icon imports (removed `Download`, `MoreHorizontal`; added `AlertTriangle`)
- Improved plan name display logic (cleaner precedence for `planName`)

### Translations
- Added `export.json` translation keys for both EN and FR

## Type of change

- [x] Refactoring / Documentation
- [x] New feature (inline plan name editing)

## Checklist

- [x] TypeScript build passes
- [x] Bilingual texts FR/EN (inline editing, date dialog, export menu)
- [x] Extracted shared utilities (`getCurrentWeek`, `PlanExportMenu`)
- [x] Tested export flows and inline editing in app

https://claude.ai/code/session_01HoTnDa57tk5xLamerxZbQU