### PR TITLE
fix: remove incorrect volumePercent scaling from workout duration calculations

### DIFF
--- a/src/components/domain/WorkoutStructure.tsx
+++ b/src/components/domain/WorkoutStructure.tsx
@@ -11,33 +11,27 @@ interface WorkoutStructureProps {
   workout: WorkoutTemplate;
   userZones?: ZoneRange[];
   className?: string;
-  /** Volume scaling (0-100) from plan context. Scales main set durations. */
-  volumePercent?: number;
 }
 
-export function WorkoutStructure({ workout, userZones, className, volumePercent }: WorkoutStructureProps) {
+export function WorkoutStructure({ workout, userZones, className }: WorkoutStructureProps) {
   const { t, i18n } = useTranslation("session");
   const isEn = i18n.language?.startsWith("en") ?? false;
-  const scale = volumePercent != null && volumePercent !== 100 ? volumePercent / 100 : null;
 
   const phases = [
     {
       key: "warmup",
       label: t("structure.warmup"),
       blocks: workout.warmupTemplate,
-      scale: null,
     },
     {
       key: "main",
       label: t("structure.main"),
       blocks: workout.mainSetTemplate,
-      scale, // only scale main set
     },
     {
       key: "cooldown",
       label: t("structure.cooldown"),
       blocks: workout.cooldownTemplate,
-      scale: null,
     },
   ].filter((phase) => phase.blocks.length > 0);
 
@@ -50,7 +44,7 @@ export function WorkoutStructure({ workout, userZones, className, volumePercent 
           </h4>
           <div className="space-y-2">
             {phase.blocks.map((block, index) => (
-              <BlockItem key={index} block={block} isEn={isEn} userZones={userZones} durationScale={phase.scale} />
+              <BlockItem key={index} block={block} isEn={isEn} userZones={userZones} />
             ))}
           </div>
         </div>
@@ -63,7 +57,6 @@ interface BlockItemProps {
   block: WorkoutBlock;
   isEn: boolean;
   userZones?: ZoneRange[];
-  durationScale?: number | null;
 }
 
 /**
@@ -88,7 +81,7 @@ function formatPersonalizedZone(zoneNumber: ZoneNumber, userZones: ZoneRange[]):
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
-function BlockItem({ block, isEn, userZones, durationScale }: BlockItemProps) {
+function BlockItem({ block, isEn, userZones }: BlockItemProps) {
   const description = isEn && block.descriptionEn
     ? block.descriptionEn
     : block.description;
@@ -98,11 +91,10 @@ function BlockItem({ block, isEn, userZones, durationScale }: BlockItemProps) {
     ? formatPersonalizedZone(zoneNumber, userZones)
     : null;
 
-  // Build duration/meta string (scale if from plan)
+  // Build duration/meta string
   const metaParts: string[] = [];
   if (block.durationMin) {
-    const scaledDuration = durationScale ? Math.round(block.durationMin * durationScale) : block.durationMin;
-    metaParts.push(`${scaledDuration} min`);
+    metaParts.push(`${block.durationMin} min`);
   }
   if (block.repetitions && block.repetitions > 1) metaParts.push(`${block.repetitions}x`);
   if (block.distance) metaParts.push(block.distance);

--- a/src/components/visualization/MiniSessionTimeline.tsx
+++ b/src/components/visualization/MiniSessionTimeline.tsx
@@ -9,7 +9,6 @@ import { transformSessionBlocks, formatDurationMinutes } from "./transforms";
 
 interface MiniSessionTimelineProps {
   workout: WorkoutTemplate;
-  volumePercent?: number;
   onClickScrollBack: () => void;
 }
 
@@ -30,7 +29,6 @@ function getHeightPercent(zone: ZoneNumber | null): number {
 
 export function MiniSessionTimeline({
   workout,
-  volumePercent,
   onClickScrollBack,
 }: MiniSessionTimelineProps) {
   const { i18n } = useTranslation("session");
@@ -45,9 +43,8 @@ export function MiniSessionTimeline({
         cooldown: workout.cooldownTemplate,
       },
       isEn,
-      volumePercent
     );
-  }, [workout, isEn, volumePercent]);
+  }, [workout, isEn]);
 
   if (data.segments.length === 0 || !data.hasZoneData) return null;
 

--- a/src/components/visualization/SessionTimeline.tsx
+++ b/src/components/visualization/SessionTimeline.tsx
@@ -24,8 +24,6 @@ import {
 interface SessionTimelineProps {
   workout: WorkoutTemplate;
   className?: string;
-  /** Volume scaling (0-100) from plan context. Scales main set durations. */
-  volumePercent?: number;
 }
 
 /**
@@ -94,7 +92,7 @@ function SegmentTooltipContent({ segment, t }: SegmentTooltipContentProps) {
   );
 }
 
-export function SessionTimeline({ workout, className, volumePercent }: SessionTimelineProps) {
+export function SessionTimeline({ workout, className }: SessionTimelineProps) {
   const { t, i18n } = useTranslation("session");
   const isEn = i18n.language?.startsWith("en") ?? false;
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -108,9 +106,8 @@ export function SessionTimeline({ workout, className, volumePercent }: SessionTi
         cooldown: workout.cooldownTemplate,
       },
       isEn,
-      volumePercent
     );
-  }, [workout, isEn, volumePercent]);
+  }, [workout, isEn]);
 
   if (segments.length === 0) {
     return (

--- a/src/components/visualization/ZoneDistribution.tsx
+++ b/src/components/visualization/ZoneDistribution.tsx
@@ -12,11 +12,9 @@ import { cn } from "@/lib/utils";
 interface ZoneDistributionProps {
   workout: WorkoutTemplate;
   className?: string;
-  /** Volume scaling (0-100) from plan context. Scales main set durations. */
-  volumePercent?: number;
 }
 
-export function ZoneDistribution({ workout, className, volumePercent }: ZoneDistributionProps) {
+export function ZoneDistribution({ workout, className }: ZoneDistributionProps) {
   const { i18n } = useTranslation();
   const isEn = i18n.language?.startsWith("en") ?? false;
 
@@ -28,9 +26,8 @@ export function ZoneDistribution({ workout, className, volumePercent }: ZoneDist
         cooldown: workout.cooldownTemplate,
       },
       isEn,
-      volumePercent
     );
-  }, [workout, isEn, volumePercent]);
+  }, [workout, isEn]);
 
   if (zoneBreakdown.length === 0) {
     return null;

--- a/src/components/visualization/transforms.ts
+++ b/src/components/visualization/transforms.ts
@@ -343,17 +343,14 @@ function blockToSegments(
 }
 
 /**
- * Transform session blocks into complete visualization data
- * @param volumePercent - optional volume scaling (0-100) from plan context. Only scales main set segments.
+ * Transform session blocks into complete visualization data.
  */
 export function transformSessionBlocks(
   blocks: SessionBlocks,
   isEn: boolean = false,
-  volumePercent?: number
 ): SessionVisualizationData {
   const allSegments: TimelineSegment[] = [];
   let segmentIndex = 0;
-  const scale = volumePercent != null ? volumePercent / 100 : 1;
 
   // Process each block type in order
   const blockTypes: Array<{ type: BlockType; blocks: WorkoutBlock[] }> = [
@@ -365,12 +362,6 @@ export function transformSessionBlocks(
   for (const { type, blocks: typeBlocks } of blockTypes) {
     for (const block of typeBlocks) {
       const segments = blockToSegments(block, type, segmentIndex);
-      // Scale main set durations when volumePercent is provided
-      if (type === "main" && scale !== 1) {
-        for (const seg of segments) {
-          seg.durationMin = seg.durationMin * scale;
-        }
-      }
       allSegments.push(...segments);
       segmentIndex++;
     }

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -88,7 +88,7 @@
     }
   },
   "planContext": {
-    "banner": "In your plan (week {{week}}, {{volume}}% volume): ~{{duration}} min",
+    "banner": "In your plan (week {{week}}): ~{{duration}} min",
     "fullSession": "(full session: {{duration}} min)"
   },
   "science": {

--- a/src/i18n/locales/fr/session.json
+++ b/src/i18n/locales/fr/session.json
@@ -88,7 +88,7 @@
     }
   },
   "planContext": {
-    "banner": "Dans votre plan (semaine {{week}}, {{volume}}% volume) : ~{{duration}} min",
+    "banner": "Dans votre plan (semaine {{week}}) : ~{{duration}} min",
     "fullSession": "(séance complète : {{duration}} min)"
   },
   "science": {

--- a/src/lib/planGenerator/selector.ts
+++ b/src/lib/planGenerator/selector.ts
@@ -96,11 +96,10 @@ function estimateBlocksDuration(blocks: WorkoutBlock[]): number {
 }
 
 /**
- * Estimate workout duration with volume scaling.
- * Warmup and cooldown keep their full duration.
- * Only the main set is scaled by volume percentage.
+ * Estimate workout duration from template blocks.
+ * Returns the base (unscaled) duration: warmup + main + cooldown.
  */
-function estimateWorkoutDuration(workout: WorkoutTemplate, volumePercent: number): number {
+function estimateWorkoutDuration(workout: WorkoutTemplate): number {
   const warmupMin = estimateBlocksDuration(workout.warmupTemplate || []);
   const mainMin = estimateBlocksDuration(workout.mainSetTemplate || []);
   const cooldownMin = estimateBlocksDuration(workout.cooldownTemplate || []);
@@ -111,14 +110,12 @@ function estimateWorkoutDuration(workout: WorkoutTemplate, volumePercent: number
     const warmup = Math.max(0, warmupMin);
     const main = Math.max(0, mainMin);
     const cooldown = Math.max(0, cooldownMin);
-    // Scale only the main set by volume %
-    const scaledMain = Math.round(main * (volumePercent / 100));
-    return Math.round(warmup + scaledMain + cooldown);
+    return Math.round(warmup + main + cooldown);
   }
 
-  // Fallback to typicalDuration scaled by volume
+  // Fallback to typicalDuration average
   const avg = (workout.typicalDuration.min + workout.typicalDuration.max) / 2;
-  return Math.round(avg * (volumePercent / 100));
+  return Math.round(avg);
 }
 
 // ── Internal selector ──────────────────────────────────────────────
@@ -130,7 +127,6 @@ function findBestWorkout(
   raceDistance: RaceDistance,
   allWorkouts: WorkoutTemplate[],
   usedWorkoutIds: string[],
-  _volumePercent: number,
   slotType: string,
   _elevationGain?: number,
 ): WorkoutSelection | null {
@@ -243,8 +239,7 @@ function findBestWorkout(
 
   const workout = finalList[0];
 
-  // Scale only the main set by volume %, keep warmup/cooldown full duration
-  const estimatedDurationMin = estimateWorkoutDuration(workout, _volumePercent);
+  const estimatedDurationMin = estimateWorkoutDuration(workout);
 
   return {
     workoutId: workout.id,
@@ -262,7 +257,7 @@ function findBestWorkout(
  * 1. For each preferred session type in the slot, try to find a match
  * 2. Filter by category, phase, difficulty, load, and distance tags
  * 3. Sort by priority score, prefer unused workouts for variety
- * 4. Calculate estimated duration adjusted by volume percentage
+ * 4. Calculate estimated duration from template blocks
  */
 export function selectWorkout(
   slot: WeekSlot,
@@ -271,7 +266,7 @@ export function selectWorkout(
   raceDistance: RaceDistance,
   allWorkouts: WorkoutTemplate[],
   usedWorkoutIds: string[], // IDs used in last 3 weeks
-  volumePercent: number,
+  _volumePercent: number,
   elevationGain?: number,
 ): WorkoutSelection | null {
   // Try each preferred session type in order
@@ -283,7 +278,6 @@ export function selectWorkout(
       raceDistance,
       allWorkouts,
       usedWorkoutIds,
-      volumePercent,
       slot.slotType,
       elevationGain,
     );

--- a/src/lib/planGenerator/sessionBuilder.ts
+++ b/src/lib/planGenerator/sessionBuilder.ts
@@ -110,7 +110,6 @@ export function buildSession(ctx: SessionBuildContext): SessionBuildResult | nul
   // Step 4: Compute pace-aware duration
   const duration = estimatePaceAwareDuration(
     workout,
-    ctx.volumePercent,
     ctx.paces,
     scaledReps,
   );
@@ -196,7 +195,6 @@ function scaleWorkout(workout: WorkoutTemplate, progression: number): number | n
  */
 function estimatePaceAwareDuration(
   workout: WorkoutTemplate,
-  volumePercent: number,
   paces: TrainingPaces,
   scaledReps: number | null,
 ): number {
@@ -216,14 +214,12 @@ function estimatePaceAwareDuration(
   const cooldownMin = cooldown >= 0 ? cooldown : 0;
 
   if (mainDuration >= 0) {
-    // Scale only main set by volume %
-    const scaledMain = Math.round(mainDuration * (volumePercent / 100));
-    return Math.round(warmupMin + scaledMain + cooldownMin);
+    return Math.round(warmupMin + mainDuration + cooldownMin);
   }
 
   // Fallback to typicalDuration
   const avg = (workout.typicalDuration.min + workout.typicalDuration.max) / 2;
-  return Math.round(avg * (volumePercent / 100));
+  return Math.round(avg);
 }
 
 /**

--- a/src/pages/PlanViewPage.tsx
+++ b/src/pages/PlanViewPage.tsx
@@ -1049,23 +1049,9 @@ export function PlanViewPage() {
                                   </Badge>
                                 )}
                                 {!isRaceDay && !session.workoutId.startsWith("__activity_") && (
-                                  <span
-                                    className="text-xs text-muted-foreground flex items-center gap-1"
-                                    title={
-                                      week.volumePercent < 100
-                                        ? (isEn
-                                            ? `Duration adjusted to ${week.volumePercent}% volume (main set scaled, warm-up/cool-down unchanged)`
-                                            : `Durée ajustée au volume ${week.volumePercent}% (corps de séance réduit, échauffement/retour au calme inchangés)`)
-                                        : ""
-                                    }
-                                  >
+                                  <span className="text-xs text-muted-foreground flex items-center gap-1">
                                     <Clock className="size-3" />
                                     {session.estimatedDurationMin}min
-                                    {week.volumePercent < 100 && (
-                                      <span className="text-[10px] opacity-60">
-                                        ({week.volumePercent}%)
-                                      </span>
-                                    )}
                                   </span>
                                 )}
                                 {!isRaceDay && (

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -188,13 +188,12 @@ export function WorkoutDetailPage() {
   }
 
   const dominantZone = getDominantZone(workout);
-  // Plan context: scaled duration when coming from a plan
-  const planVolumePercent = locationState?.volumePercent;
+  // Plan context: duration from plan generation (may differ from template for long runs)
   const planWeekNumber = locationState?.weekNumber;
   const planEstimatedDuration = locationState?.estimatedDurationMin;
-  const hasPlanContext = locationState?.from === "plan" && (planEstimatedDuration != null || (planVolumePercent != null && planVolumePercent !== 100));
+  const hasPlanContext = locationState?.from === "plan" && planEstimatedDuration != null;
 
-  // Base (unscaled) session data
+  // Base session data from workout template
   const baseSessionData = transformSessionBlocks(
     {
       warmup: workout.warmupTemplate,
@@ -205,21 +204,9 @@ export function WorkoutDetailPage() {
   );
   const baseDuration = Math.round(baseSessionData.totalDurationMin);
 
-  // Scaled session data when coming from a plan
-  const sessionData = hasPlanContext
-    ? transformSessionBlocks(
-        {
-          warmup: workout.warmupTemplate,
-          mainSet: workout.mainSetTemplate,
-          cooldown: workout.cooldownTemplate,
-        },
-        isEn,
-        planVolumePercent
-      )
-    : baseSessionData;
   const duration = (locationState?.from === "plan" && planEstimatedDuration != null)
     ? Math.round(planEstimatedDuration)
-    : Math.round(sessionData.totalDurationMin);
+    : baseDuration;
 
   const CategoryIcon = CATEGORY_ICONS[workout.category];
 
@@ -362,11 +349,11 @@ export function WorkoutDetailPage() {
         </div>
 
         {/* Plan context banner */}
-        {hasPlanContext && (
+        {hasPlanContext && duration !== baseDuration && (
           <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-2.5 text-sm flex items-center gap-2">
             <Clock className="size-4 text-primary shrink-0" />
             <span>
-              {t("session:planContext.banner", { week: planWeekNumber, volume: planVolumePercent, duration })}
+              {t("session:planContext.banner", { week: planWeekNumber, duration })}
               <span className="text-muted-foreground ml-1">
                 {t("session:planContext.fullSession", { duration: baseDuration })}
               </span>
@@ -452,7 +439,6 @@ export function WorkoutDetailPage() {
           <div className="sticky top-12 z-40 -mx-4 md:-mx-6 lg:-mx-8 px-4 md:px-6 lg:px-8 bg-background/90 backdrop-blur-sm md:backdrop-blur-md shadow-[0_1px_3px_0_rgba(0,0,0,0.1),0_6px_12px_-4px_rgba(0,0,0,0.15)] dark:shadow-[0_1px_3px_0_rgba(0,0,0,0.3),0_6px_12px_-4px_rgba(0,0,0,0.4)] border-b border-border/30 will-change-[transform,opacity] animate-slide-in-top print:hidden">
             <MiniSessionTimeline
               workout={workout}
-              volumePercent={hasPlanContext ? planVolumePercent : undefined}
               onClickScrollBack={() => {
                 timelineCardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
               }}
@@ -472,7 +458,7 @@ export function WorkoutDetailPage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <SessionTimeline workout={workout} volumePercent={hasPlanContext ? planVolumePercent : undefined} />
+                  <SessionTimeline workout={workout} />
                 </CardContent>
               </Card>
             </div>
@@ -485,7 +471,7 @@ export function WorkoutDetailPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <WorkoutStructure workout={workout} userZones={hasUserZones ? userZones : undefined} volumePercent={hasPlanContext ? planVolumePercent : undefined} />
+                <WorkoutStructure workout={workout} userZones={hasUserZones ? userZones : undefined} />
               </CardContent>
             </Card>
 
@@ -506,7 +492,7 @@ export function WorkoutDetailPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <ZoneDistribution workout={workout} volumePercent={hasPlanContext ? planVolumePercent : undefined} />
+                <ZoneDistribution workout={workout} />
               </CardContent>
             </Card>
 


### PR DESCRIPTION
volumePercent (weekKm/peakKm ratio, 0-100) was being misused to scale
individual workout durations. This produced wrong durations (e.g. 31% volume
→ 20min main set instead of 65min). Weekly volume is achieved through session
count, workout selection, and long-run target distances — not by shrinking
each workout's main set.

Removes volumePercent scaling from:
- estimatePaceAwareDuration (sessionBuilder)
- estimateWorkoutDuration (selector)
- transformSessionBlocks (visualization)
- All visualization components (SessionTimeline, ZoneDistribution, etc.)
- WorkoutDetailPage banner and WorkoutStructure block display

https://claude.ai/code/session_01Rvoz8WEB3xPj8BD2ZchNXH