### PR TITLE
feat(calculators): add MET (Metabolic Equivalent) calculator and guide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ const PaceConverterPage = lazy(() => import("@/pages/PaceConverterPage").then(m 
 const PaceTablePage = lazy(() => import("@/pages/PaceTablePage").then(m => ({ default: m.PaceTablePage })));
 const AgeGradedPage = lazy(() => import("@/pages/AgeGradedPage").then(m => ({ default: m.AgeGradedPage })));
 const WhatIfPage = lazy(() => import("@/pages/WhatIfPage").then(m => ({ default: m.WhatIfPage })));
+const MetCalculatorPage = lazy(() => import("@/pages/MetCalculatorPage").then(m => ({ default: m.MetCalculatorPage })));
+const MetGuidePage = lazy(() => import("@/pages/MetGuidePage").then(m => ({ default: m.MetGuidePage })));
 const WorkoutBuilderPage = lazy(() => import("@/pages/WorkoutBuilderPage").then(m => ({ default: m.WorkoutBuilderPage })));
 const RaceSimulatorPage = lazy(() => import("@/pages/RaceSimulatorPage").then(m => ({ default: m.RaceSimulatorPage })));
 const CompareHubPage = lazy(() => import("@/pages/CompareHubPage").then(m => ({ default: m.CompareHubPage })));
@@ -282,6 +284,7 @@ function App() {
                           <Route path="/calculators/equivalence" element={<RaceEquivalencePage />} />
                           <Route path="/calculators/age-graded" element={<AgeGradedPage />} />
                           <Route path="/calculators/what-if" element={<WhatIfPage />} />
+                          <Route path="/calculators/met" element={<MetCalculatorPage />} />
                           <Route path="/settings" element={<SettingsPage />} />
                           <Route path="/profile" element={<RunnerProfilePage />} />
                           <Route path="/favorites" element={<FavoritesPage />} />
@@ -300,6 +303,7 @@ function App() {
                           <Route path="/guides/nutrition" element={<NutritionGuidePage />} />
                           <Route path="/guides/race-prep" element={<RacePrepGuidePage />} />
                           <Route path="/guides/warmup" element={<WarmupGuidePage />} />
+                          <Route path="/guides/met" element={<MetGuidePage />} />
                           <Route path="/nutrition" element={<NutritionHubPage />} />
                           <Route path="/plans" element={<PlansPage />} />
                           <Route path="/plans/methodology" element={<PlanMethodologyPage />} />

--- a/src/components/domain/MetCalculator.tsx
+++ b/src/components/domain/MetCalculator.tsx
@@ -1,0 +1,268 @@
+import { useMemo, useState, type ChangeEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { Flame, Info, ExternalLink } from "@/components/icons";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { usePickLang } from "@/lib/i18n-utils";
+import {
+  MET_ACTIVITIES,
+  CATEGORY_ORDER,
+  classifyIntensity,
+  computeCalories,
+  computeVO2,
+  type MetActivity,
+  type MetCategory,
+} from "@/lib/metCalculator";
+
+const INTENSITY_COLOR: Record<ReturnType<typeof classifyIntensity>, string> = {
+  light: "bg-zone-2/15 text-zone-2",
+  moderate: "bg-zone-3/15 text-zone-3",
+  vigorous: "bg-zone-5/15 text-zone-5",
+};
+
+export function MetCalculator() {
+  const { t } = useTranslation("calculators");
+  const pickLang = usePickLang();
+
+  const [weight, setWeight] = useState<string>("70");
+  const [duration, setDuration] = useState<string>("45");
+  const [activityId, setActivityId] = useState<string>(MET_ACTIVITIES[2].id); // Course 10 km/h
+  const [activeCategory, setActiveCategory] = useState<MetCategory>("running");
+  const [customMet, setCustomMet] = useState<string>("8");
+
+  const weightKg = parseFloat(weight) || 0;
+  const durationMin = parseFloat(duration) || 0;
+  const customMetValue = parseFloat(customMet) || 0;
+
+  const selectedActivity = useMemo(
+    () => MET_ACTIVITIES.find((a) => a.id === activityId) ?? MET_ACTIVITIES[0],
+    [activityId],
+  );
+
+  const activitiesByCategory = useMemo(() => {
+    const map = new Map<MetCategory, MetActivity[]>();
+    for (const cat of CATEGORY_ORDER) map.set(cat, []);
+    for (const activity of MET_ACTIVITIES) {
+      map.get(activity.category)?.push(activity);
+    }
+    return map;
+  }, []);
+
+  function ResultsBlock({ met }: { met: number }) {
+    const kcal = computeCalories(met, weightKg, durationMin);
+    const vo2 = computeVO2(met);
+    const intensity = classifyIntensity(met);
+    const valid = met > 0 && weightKg > 0 && durationMin > 0;
+
+    if (!valid) {
+      return (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+          <Info className="size-4" />
+          {t("calculateurs.met.fillInputs")}
+        </div>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="rounded-xl border border-border/50 bg-gradient-to-br from-primary/10 to-transparent p-4">
+          <div className="text-xs text-muted-foreground mb-1">
+            {t("calculateurs.met.calories")}
+          </div>
+          <div className="text-2xl font-bold tabular-nums flex items-baseline gap-1">
+            <Flame className="size-5 text-primary" />
+            {Math.round(kcal)}
+            <span className="text-sm font-normal text-muted-foreground">kcal</span>
+          </div>
+          <div className="text-xs text-muted-foreground mt-1">
+            {t("calculateurs.met.formula")}
+          </div>
+        </div>
+        <div className="rounded-xl border border-border/50 p-4">
+          <div className="text-xs text-muted-foreground mb-1">MET</div>
+          <div className="text-2xl font-bold tabular-nums">{met.toFixed(1)}</div>
+          <Badge className={cn("mt-1 text-xs", INTENSITY_COLOR[intensity])} variant="secondary">
+            {t(`calculateurs.met.intensity.${intensity}`)}
+          </Badge>
+        </div>
+        <div className="rounded-xl border border-border/50 p-4">
+          <div className="text-xs text-muted-foreground mb-1">
+            {t("calculateurs.met.vo2")}
+          </div>
+          <div className="text-2xl font-bold tabular-nums flex items-baseline gap-1">
+            {vo2.toFixed(1)}
+            <span className="text-sm font-normal text-muted-foreground">
+              ml/kg/min
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const sharedInputs = (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="space-y-2">
+        <label htmlFor="met-weight" className="text-sm font-medium">
+          {t("calculateurs.met.weight")}
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="met-weight"
+            type="number"
+            min={20}
+            max={250}
+            step={1}
+            placeholder="70"
+            value={weight}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setWeight(e.target.value)}
+            className="flex h-9 w-full max-w-[120px] rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="text-sm text-muted-foreground">kg</span>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="met-duration" className="text-sm font-medium">
+          {t("calculateurs.met.duration")}
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="met-duration"
+            type="number"
+            min={1}
+            max={600}
+            step={1}
+            placeholder="45"
+            value={duration}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setDuration(e.target.value)}
+            className="flex h-9 w-full max-w-[120px] rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="text-sm text-muted-foreground">min</span>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Flame className="size-5 text-primary" />
+          {t("calculateurs.met.calculatorTitle")}
+        </CardTitle>
+        <CardDescription>
+          {t("calculateurs.met.calculatorDescription")}{" "}
+          <a
+            href="https://fr.wikipedia.org/wiki/%C3%89quivalent_m%C3%A9tabolique"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-0.5 text-primary hover:underline"
+          >
+            Wikipédia
+            <ExternalLink className="size-3" />
+          </a>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {sharedInputs}
+
+        <Tabs defaultValue="activity">
+          <TabsList className="grid grid-cols-2 w-full max-w-md">
+            <TabsTrigger value="activity">
+              {t("calculateurs.met.tabActivity")}
+            </TabsTrigger>
+            <TabsTrigger value="custom">
+              {t("calculateurs.met.tabCustom")}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="activity" className="space-y-4 pt-4">
+            {/* Category selector */}
+            <div className="flex flex-wrap gap-2">
+              {CATEGORY_ORDER.map((cat) => (
+                <button
+                  key={cat}
+                  type="button"
+                  onClick={() => setActiveCategory(cat)}
+                  className={cn(
+                    "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
+                    activeCategory === cat
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground hover:bg-muted/70",
+                  )}
+                >
+                  {t(`calculateurs.met.category.${cat}`)}
+                </button>
+              ))}
+            </div>
+
+            {/* Activity grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {(activitiesByCategory.get(activeCategory) ?? []).map((activity) => {
+                const intensity = classifyIntensity(activity.met);
+                const isActive = activityId === activity.id;
+                return (
+                  <button
+                    key={activity.id}
+                    type="button"
+                    onClick={() => setActivityId(activity.id)}
+                    className={cn(
+                      "flex items-center justify-between gap-3 rounded-lg border p-3 text-left text-sm transition-all",
+                      isActive
+                        ? "border-primary bg-primary/5 shadow-sm"
+                        : "border-border hover:border-primary/40 hover:bg-accent/50",
+                    )}
+                  >
+                    <span className="flex-1 min-w-0">{pickLang(activity, "label")}</span>
+                    <span className="flex items-center gap-2 shrink-0">
+                      <Badge variant="secondary" className={cn("text-xs", INTENSITY_COLOR[intensity])}>
+                        {activity.met.toFixed(1)} MET
+                      </Badge>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <ResultsBlock met={selectedActivity.met} />
+          </TabsContent>
+
+          <TabsContent value="custom" className="space-y-4 pt-4">
+            <div className="space-y-2">
+              <label htmlFor="met-custom" className="text-sm font-medium">
+                {t("calculateurs.met.customMetLabel")}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="met-custom"
+                  type="number"
+                  min={0.5}
+                  max={25}
+                  step={0.1}
+                  placeholder="8"
+                  value={customMet}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCustomMet(e.target.value)}
+                  className="flex h-9 w-full max-w-[120px] rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+                <span className="text-sm text-muted-foreground">MET</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {t("calculateurs.met.customMetHelp")}
+              </p>
+            </div>
+
+            <ResultsBlock met={customMetValue} />
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/data/guides/met/data.ts
+++ b/src/data/guides/met/data.ts
@@ -1,0 +1,178 @@
+import type { MetSection } from "./types";
+
+export const metSections: MetSection[] = [
+  {
+    id: "what-is-met",
+    title: "Qu'est-ce que le MET ?",
+    titleEn: "What is MET?",
+    icon: "Info",
+    content: [
+      {
+        type: "paragraph",
+        text: "L'équivalent métabolique (Metabolic Equivalent of Task, abrégé MET) est une unité standardisée qui exprime l'intensité d'une activité physique en multiple du métabolisme de repos. Par convention, 1 MET correspond à la consommation d'oxygène d'un adulte assis au repos, soit environ 3,5 ml d'O₂ par kilogramme de poids corporel et par minute.",
+        textEn: "The Metabolic Equivalent of Task (MET) is a standardized unit that expresses the intensity of a physical activity as a multiple of the resting metabolic rate. By convention, 1 MET corresponds to the oxygen consumption of an adult sitting at rest — approximately 3.5 ml of O₂ per kilogram of body weight per minute.",
+      },
+      {
+        type: "paragraph",
+        text: "L'unité a été proposée dans les années 1960 puis popularisée par le Compendium of Physical Activities (Ainsworth et al., 1993, mises à jour en 2000 et 2011), une base de données qui recense plus de 800 activités et leur valeur MET de référence. Le MET est aujourd'hui utilisé en cardiologie, en médecine du sport, en santé publique et dans la plupart des montres connectées pour estimer la dépense énergétique.",
+        textEn: "The unit was proposed in the 1960s and popularized by the Compendium of Physical Activities (Ainsworth et al., 1993, updated in 2000 and 2011) — a database listing over 800 activities and their reference MET values. MET is now used in cardiology, sports medicine, public health, and most fitness watches to estimate energy expenditure.",
+      },
+      {
+        type: "tip",
+        text: "Une approximation pratique : 1 MET ≈ 1 kcal par kilogramme de poids corporel et par heure. C'est cette équivalence qui permet de calculer la dépense énergétique d'une séance.",
+        textEn: "A practical approximation: 1 MET ≈ 1 kcal per kilogram of body weight per hour. This equivalence is what enables energy expenditure to be calculated from MET values.",
+      },
+    ],
+  },
+  {
+    id: "formula",
+    title: "La formule de calcul",
+    titleEn: "The calculation formula",
+    icon: "Calculator",
+    content: [
+      {
+        type: "paragraph",
+        text: "Pour estimer la dépense énergétique d'une activité, on multiplie la valeur MET par le poids du sportif (en kg) et par la durée (en heures).",
+        textEn: "To estimate the energy expenditure of an activity, multiply the MET value by the athlete's weight (in kg) and by the duration (in hours).",
+      },
+      {
+        type: "formula",
+        formula: "Calories (kcal) = MET × Poids (kg) × Durée (h)",
+      },
+      {
+        type: "paragraph",
+        text: "Exemple : un coureur de 70 kg qui court à 10 km/h (10 MET) pendant 45 minutes dépense environ 10 × 70 × 0,75 = 525 kcal.",
+        textEn: "Example: a 70 kg runner running at 10 km/h (10 MET) for 45 minutes burns roughly 10 × 70 × 0.75 = 525 kcal.",
+      },
+      {
+        type: "list",
+        text: "Conversions utiles",
+        textEn: "Useful conversions",
+        items: [
+          {
+            text: "1 MET = 3,5 ml d'O₂ / kg / min (consommation d'oxygène au repos)",
+            textEn: "1 MET = 3.5 ml of O₂ / kg / min (resting oxygen consumption)",
+          },
+          {
+            text: "1 MET ≈ 1 kcal / kg / h (dépense énergétique au repos)",
+            textEn: "1 MET ≈ 1 kcal / kg / h (resting energy expenditure)",
+          },
+          {
+            text: "VO₂ d'une activité (ml/kg/min) = MET × 3,5",
+            textEn: "Activity VO₂ (ml/kg/min) = MET × 3.5",
+          },
+        ],
+      },
+      {
+        type: "warning",
+        text: "Le MET est une moyenne statistique. Il ne tient pas compte de l'âge, du sexe, du niveau d'entraînement, ni du rendement individuel. L'estimation reste un ordre de grandeur — comptez ±10 à 15 % d'incertitude.",
+        textEn: "MET is a statistical average. It does not account for age, sex, training level, or individual efficiency. The estimate is a ballpark figure — expect ±10–15% uncertainty.",
+      },
+    ],
+  },
+  {
+    id: "intensity",
+    title: "Catégories d'intensité",
+    titleEn: "Intensity categories",
+    icon: "Activity",
+    content: [
+      {
+        type: "paragraph",
+        text: "Les institutions de santé (OMS, ACSM, CDC) classent les activités en trois grandes intensités selon leur valeur MET. Cette classification permet de prescrire des recommandations d'activité physique.",
+        textEn: "Health institutions (WHO, ACSM, CDC) classify activities into three main intensity bands based on their MET value. This classification underpins physical activity recommendations.",
+      },
+      {
+        type: "table",
+        rows: [
+          {
+            label: "Activité légère",
+            labelEn: "Light activity",
+            value: "< 3 MET — marche lente, étirements, yoga doux, vaisselle",
+            valueEn: "< 3 MET — slow walk, stretching, gentle yoga, dishwashing",
+          },
+          {
+            label: "Activité modérée",
+            labelEn: "Moderate activity",
+            value: "3 à 6 MET — marche rapide, vélo loisir, musculation modérée",
+            valueEn: "3 to 6 MET — brisk walk, leisure cycling, moderate weightlifting",
+          },
+          {
+            label: "Activité vigoureuse",
+            labelEn: "Vigorous activity",
+            value: "≥ 6 MET — course à pied, vélo soutenu, natation, sports collectifs",
+            valueEn: "≥ 6 MET — running, vigorous cycling, swimming, team sports",
+          },
+        ],
+      },
+      {
+        type: "tip",
+        text: "Recommandations OMS pour adultes : au moins 150 minutes par semaine d'activité modérée (3-6 MET) ou 75 minutes d'activité vigoureuse (≥ 6 MET), ou un mélange équivalent en MET-minutes.",
+        textEn: "WHO recommendations for adults: at least 150 minutes per week of moderate-intensity activity (3-6 MET) or 75 minutes of vigorous-intensity activity (≥ 6 MET), or an equivalent combination in MET-minutes.",
+      },
+    ],
+  },
+  {
+    id: "common-values",
+    title: "Valeurs MET courantes",
+    titleEn: "Common MET values",
+    icon: "List",
+    content: [
+      {
+        type: "paragraph",
+        text: "Voici quelques valeurs de référence issues du Compendium of Physical Activities. Le calculateur intègre une base de plus de 40 activités.",
+        textEn: "Here are some reference values from the Compendium of Physical Activities. The calculator includes a database of over 40 activities.",
+      },
+      {
+        type: "table",
+        rows: [
+          { label: "Repos assis", labelEn: "Sitting at rest", value: "1,0 MET", valueEn: "1.0 MET" },
+          { label: "Marche modérée (5 km/h)", labelEn: "Moderate walk (5 km/h)", value: "3,5 MET", valueEn: "3.5 MET" },
+          { label: "Vélo loisir (16-19 km/h)", labelEn: "Leisure cycling (16-19 km/h)", value: "6,8 MET", valueEn: "6.8 MET" },
+          { label: "Course 8 km/h (7:30/km)", labelEn: "Running 8 km/h (12:00/mi)", value: "8,3 MET", valueEn: "8.3 MET" },
+          { label: "Course 10 km/h (6:00/km)", labelEn: "Running 10 km/h (9:40/mi)", value: "10,0 MET", valueEn: "10.0 MET" },
+          { label: "Course 12 km/h (5:00/km)", labelEn: "Running 12 km/h (8:00/mi)", value: "11,8 MET", valueEn: "11.8 MET" },
+          { label: "Course 16 km/h (3:45/km)", labelEn: "Running 16 km/h (6:00/mi)", value: "14,5 MET", valueEn: "14.5 MET" },
+          { label: "Natation crawl modéré", labelEn: "Moderate freestyle swim", value: "8,3 MET", valueEn: "8.3 MET" },
+          { label: "Corde à sauter", labelEn: "Jump rope", value: "12,3 MET", valueEn: "12.3 MET" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "limits",
+    title: "Limites et bonnes pratiques",
+    titleEn: "Limits and best practices",
+    icon: "AlertTriangle",
+    content: [
+      {
+        type: "list",
+        text: "Le MET sous-estime ou surestime selon les profils",
+        textEn: "MET tends to under- or over-estimate depending on the profile",
+        items: [
+          {
+            text: "Le calcul 1 MET = 3,5 ml/kg/min repose sur un adulte « standard » (homme 70 kg, 40 ans). Une femme, une personne âgée ou en surpoids aura un métabolisme de repos différent, parfois 2,5-3 ml/kg/min seulement.",
+            textEn: "The 1 MET = 3.5 ml/kg/min figure assumes a 'standard' adult (man, 70 kg, 40 years old). A woman, an older person, or someone with overweight may have a different resting metabolism — sometimes only 2.5–3 ml/kg/min.",
+          },
+          {
+            text: "Les athlètes très entraînés ont un meilleur rendement énergétique : pour une même valeur MET, ils dépensent légèrement moins d'énergie qu'une personne sédentaire.",
+            textEn: "Highly trained athletes have better energy efficiency: for the same MET value, they expend slightly less energy than a sedentary person.",
+          },
+          {
+            text: "Les valeurs du Compendium sont mesurées sur terrain plat, par temps tempéré, sans vent. Vent, dénivelé, chaleur ou altitude peuvent augmenter la dépense réelle de 10 à 30 %.",
+            textEn: "Compendium values are measured on flat terrain, in temperate weather, with no wind. Wind, elevation, heat, or altitude can raise actual expenditure by 10–30%.",
+          },
+        ],
+      },
+      {
+        type: "tip",
+        text: "Pour un suivi précis de la dépense énergétique sur l'année, croise les estimations MET avec les données de ta montre (HR, puissance) et calibre selon ton ressenti et l'évolution du poids.",
+        textEn: "For accurate yearly tracking, cross-check MET estimates with watch data (HR, power) and calibrate against your perceived effort and weight trend.",
+      },
+      {
+        type: "paragraph",
+        text: "Le MET reste un excellent outil pour comparer rapidement deux séances, planifier une dépense calorique ou prescrire un volume d'activité physique. Mais ce n'est pas un substitut à un calorimètre indirect ou à un capteur cardiaque pour les besoins précis.",
+        textEn: "MET remains an excellent tool for quickly comparing two sessions, planning caloric expenditure, or prescribing a physical activity volume. It is not, however, a substitute for indirect calorimetry or a heart rate monitor when precision is needed.",
+      },
+    ],
+  },
+];

--- a/src/data/guides/met/index.ts
+++ b/src/data/guides/met/index.ts
@@ -1,0 +1,2 @@
+export type { MetSection, MetBlock } from "./types";
+export { metSections } from "./data";

--- a/src/data/guides/met/types.ts
+++ b/src/data/guides/met/types.ts
@@ -1,0 +1,16 @@
+export interface MetSection {
+  id: string;
+  title: string;
+  titleEn: string;
+  icon: string;
+  content: MetBlock[];
+}
+
+export interface MetBlock {
+  type: "paragraph" | "list" | "tip" | "warning" | "formula" | "table";
+  text?: string;
+  textEn?: string;
+  items?: { text: string; textEn: string }[];
+  rows?: { label: string; labelEn: string; value: string; valueEn: string }[];
+  formula?: string;
+}

--- a/src/i18n/locales/en/calculators.json
+++ b/src/i18n/locales/en/calculators.json
@@ -247,6 +247,41 @@
       "deleteTitle": "Delete this scenario?",
       "deleteDescription": "This scenario will be permanently deleted. This action cannot be undone."
     },
+    "met": {
+      "seoTitle": "MET Calculator — Calories per Session",
+      "seoDescription": "Calculate calorie expenditure from the Metabolic Equivalent of Task (MET): running, cycling, swimming, strength and 40+ activities, or free MET input.",
+      "seoAppName": "MET Calculator",
+      "seoAppDescription": "Estimate the energy expenditure of a session from the MET value",
+      "seoBreadcrumb": "MET Calculator",
+      "title": "MET Calculator",
+      "description": "Estimate the calorie expenditure of a session using the Metabolic Equivalent of Task (MET).",
+      "readGuide": "Read the MET guide to understand the calculation",
+      "calculatorTitle": "Session calorie expenditure",
+      "calculatorDescription": "Computed from the formula kcal = MET × weight × duration. Reference:",
+      "weight": "Weight",
+      "duration": "Duration",
+      "tabActivity": "Activity",
+      "tabCustom": "Free MET",
+      "customMetLabel": "MET value",
+      "customMetHelp": "Enter a MET value from the Compendium of Physical Activities or another source (range 0.9 to 23).",
+      "calories": "Calories burned",
+      "formula": "MET × kg × hours",
+      "vo2": "O₂ consumption",
+      "fillInputs": "Enter your weight, duration, and pick an activity (or enter a MET value).",
+      "category": {
+        "running": "Running",
+        "cycling": "Cycling",
+        "swimming": "Swimming",
+        "walking": "Walking",
+        "strength": "Strength",
+        "other": "Other"
+      },
+      "intensity": {
+        "light": "Light",
+        "moderate": "Moderate",
+        "vigorous": "Vigorous"
+      }
+    },
     "breadcrumb": "Calculators"
   },
   "workoutBuilder": {

--- a/src/i18n/locales/en/guides.json
+++ b/src/i18n/locales/en/guides.json
@@ -97,6 +97,16 @@
     "routines": "Warm-up Routines",
     "selectRoutine": "Select a routine"
   },
+  "met": {
+    "title": "Metabolic Equivalent (MET)",
+    "subtitle": "Understanding MET, intensity bands and energy expenditure",
+    "description": "MET, intensity bands and calorie calculation",
+    "seoDescription": "Complete guide to the Metabolic Equivalent of Task (MET): definition, calculation formula, intensity classification and reference values for running, cycling, swimming and more.",
+    "seoArticleName": "Metabolic Equivalent of Task (MET) Guide",
+    "seoArticleDescription": "Everything you need to know about MET and how to estimate energy expenditure with it.",
+    "openCalculator": "Open the MET calculator",
+    "wikipediaLink": "Read the full Wikipedia article"
+  },
   "explore": "Explore",
   "home": "Home",
   "rep": "rep",

--- a/src/i18n/locales/fr/calculators.json
+++ b/src/i18n/locales/fr/calculators.json
@@ -247,6 +247,41 @@
       "deleteTitle": "Supprimer ce scénario ?",
       "deleteDescription": "Ce scénario sera définitivement supprimé. Cette action est irréversible."
     },
+    "met": {
+      "seoTitle": "Calculateur MET — Calories par séance",
+      "seoDescription": "Calculez votre dépense calorique à partir de l'équivalent métabolique (MET) : course, vélo, natation, musculation et plus de 40 activités, ou saisie MET libre.",
+      "seoAppName": "Calculateur MET",
+      "seoAppDescription": "Estimez la dépense énergétique d'une séance à partir de la valeur MET",
+      "seoBreadcrumb": "Calculateur MET",
+      "title": "Calculateur MET",
+      "description": "Estimez la dépense calorique d'une séance grâce à l'équivalent métabolique (MET).",
+      "readGuide": "Lire le guide MET pour comprendre le calcul",
+      "calculatorTitle": "Dépense calorique d'une séance",
+      "calculatorDescription": "Calcul basé sur la formule kcal = MET × poids × durée. Référence :",
+      "weight": "Poids",
+      "duration": "Durée",
+      "tabActivity": "Activité",
+      "tabCustom": "MET libre",
+      "customMetLabel": "Valeur MET",
+      "customMetHelp": "Saisissez une valeur MET issue du Compendium of Physical Activities ou d'une autre source (de 0,9 à 23).",
+      "calories": "Calories dépensées",
+      "formula": "MET × kg × heures",
+      "vo2": "Consommation O₂",
+      "fillInputs": "Renseignez votre poids, la durée et choisissez une activité (ou saisissez une valeur MET).",
+      "category": {
+        "running": "Course",
+        "cycling": "Vélo",
+        "swimming": "Natation",
+        "walking": "Marche",
+        "strength": "Musculation",
+        "other": "Autres"
+      },
+      "intensity": {
+        "light": "Léger",
+        "moderate": "Modéré",
+        "vigorous": "Vigoureux"
+      }
+    },
     "breadcrumb": "Calculateurs"
   },
   "workoutBuilder": {

--- a/src/i18n/locales/fr/guides.json
+++ b/src/i18n/locales/fr/guides.json
@@ -97,6 +97,16 @@
     "routines": "Routines d'échauffement",
     "selectRoutine": "Sélectionnez une routine"
   },
+  "met": {
+    "title": "Équivalent métabolique (MET)",
+    "subtitle": "Comprendre les MET, intensités et dépense calorique",
+    "description": "MET, intensités et calcul des calories",
+    "seoDescription": "Guide complet sur l'équivalent métabolique (MET) : définition, formule de calcul, classification d'intensité et valeurs de référence pour la course, le vélo, la natation et plus.",
+    "seoArticleName": "Guide de l'équivalent métabolique (MET)",
+    "seoArticleDescription": "Tout comprendre sur le MET et son utilisation pour estimer la dépense énergétique.",
+    "openCalculator": "Ouvrir le calculateur MET",
+    "wikipediaLink": "Article Wikipédia complet"
+  },
   "explore": "Explorer",
   "home": "Accueil",
   "rep": "rep",

--- a/src/lib/metCalculator.ts
+++ b/src/lib/metCalculator.ts
@@ -1,0 +1,127 @@
+/**
+ * MET (Metabolic Equivalent of Task) calculator.
+ *
+ * Reference: Compendium of Physical Activities (Ainsworth et al., 2011 update)
+ * https://fr.wikipedia.org/wiki/%C3%89quivalent_m%C3%A9tabolique
+ *
+ * 1 MET = 3.5 ml O₂ / kg / min ≈ 1 kcal / kg / h (resting metabolic rate)
+ * Energy expenditure (kcal) = MET × weight (kg) × duration (h)
+ */
+
+export type MetCategory =
+  | "running"
+  | "cycling"
+  | "swimming"
+  | "walking"
+  | "strength"
+  | "other";
+
+export interface MetActivity {
+  id: string;
+  category: MetCategory;
+  met: number;
+  label: string;
+  labelEn: string;
+}
+
+export const MET_ACTIVITIES: MetActivity[] = [
+  // Running
+  { id: "run-jog", category: "running", met: 6.0, label: "Jogging (6 km/h)", labelEn: "Jogging (6 km/h)" },
+  { id: "run-8", category: "running", met: 8.3, label: "Course 8 km/h (7:30/km)", labelEn: "Running 8 km/h (12:00/mi)" },
+  { id: "run-10", category: "running", met: 10.0, label: "Course 10 km/h (6:00/km)", labelEn: "Running 10 km/h (9:40/mi)" },
+  { id: "run-12", category: "running", met: 11.8, label: "Course 12 km/h (5:00/km)", labelEn: "Running 12 km/h (8:00/mi)" },
+  { id: "run-14", category: "running", met: 13.5, label: "Course 14 km/h (4:17/km)", labelEn: "Running 14 km/h (6:54/mi)" },
+  { id: "run-16", category: "running", met: 14.5, label: "Course 16 km/h (3:45/km)", labelEn: "Running 16 km/h (6:00/mi)" },
+  { id: "run-17", category: "running", met: 16.0, label: "Course 17,5 km/h (3:25/km)", labelEn: "Running 17.5 km/h (5:30/mi)" },
+  { id: "run-trail", category: "running", met: 9.0, label: "Trail running modéré", labelEn: "Trail running, moderate" },
+
+  // Cycling
+  { id: "bike-light", category: "cycling", met: 4.0, label: "Vélo loisir (< 16 km/h)", labelEn: "Cycling, leisure (< 16 km/h)" },
+  { id: "bike-mod", category: "cycling", met: 6.8, label: "Vélo modéré (16-19 km/h)", labelEn: "Cycling, moderate (16-19 km/h)" },
+  { id: "bike-vig", category: "cycling", met: 8.0, label: "Vélo soutenu (19-22 km/h)", labelEn: "Cycling, vigorous (19-22 km/h)" },
+  { id: "bike-fast", category: "cycling", met: 10.0, label: "Vélo rapide (22-25 km/h)", labelEn: "Cycling, fast (22-25 km/h)" },
+  { id: "bike-race", category: "cycling", met: 12.0, label: "Vélo course (25-30 km/h)", labelEn: "Cycling, racing (25-30 km/h)" },
+  { id: "bike-elite", category: "cycling", met: 15.8, label: "Vélo course (> 30 km/h)", labelEn: "Cycling, racing (> 30 km/h)" },
+  { id: "bike-mtb", category: "cycling", met: 8.5, label: "VTT", labelEn: "Mountain biking" },
+  { id: "bike-spin", category: "cycling", met: 8.5, label: "Vélo en salle (spinning)", labelEn: "Indoor cycling (spinning)" },
+
+  // Swimming
+  { id: "swim-light", category: "swimming", met: 5.8, label: "Crawl léger", labelEn: "Freestyle, light" },
+  { id: "swim-mod", category: "swimming", met: 8.3, label: "Crawl modéré", labelEn: "Freestyle, moderate" },
+  { id: "swim-vig", category: "swimming", met: 9.8, label: "Crawl rapide", labelEn: "Freestyle, vigorous" },
+  { id: "swim-breast", category: "swimming", met: 5.3, label: "Brasse", labelEn: "Breaststroke" },
+  { id: "swim-back", category: "swimming", met: 4.8, label: "Dos crawlé", labelEn: "Backstroke" },
+  { id: "swim-fly", category: "swimming", met: 13.8, label: "Papillon", labelEn: "Butterfly" },
+
+  // Walking
+  { id: "walk-slow", category: "walking", met: 2.0, label: "Marche lente (3 km/h)", labelEn: "Walking, slow (3 km/h)" },
+  { id: "walk-mod", category: "walking", met: 3.5, label: "Marche modérée (5 km/h)", labelEn: "Walking, moderate (5 km/h)" },
+  { id: "walk-brisk", category: "walking", met: 5.0, label: "Marche rapide (6 km/h)", labelEn: "Walking, brisk (6 km/h)" },
+  { id: "walk-fast", category: "walking", met: 6.3, label: "Marche très rapide (7 km/h)", labelEn: "Walking, very brisk (7 km/h)" },
+  { id: "walk-hike", category: "walking", met: 6.0, label: "Randonnée (terrain vallonné)", labelEn: "Hiking (hilly)" },
+  { id: "walk-stairs", category: "walking", met: 8.8, label: "Montée d'escaliers", labelEn: "Climbing stairs" },
+
+  // Strength
+  { id: "str-light", category: "strength", met: 3.5, label: "Musculation modérée", labelEn: "Weightlifting, moderate" },
+  { id: "str-vig", category: "strength", met: 6.0, label: "Musculation vigoureuse", labelEn: "Weightlifting, vigorous" },
+  { id: "str-cross", category: "strength", met: 8.0, label: "Cross-training / HIIT", labelEn: "Cross-training / HIIT" },
+  { id: "str-circuit", category: "strength", met: 8.0, label: "Circuit training", labelEn: "Circuit training" },
+  { id: "str-calist", category: "strength", met: 4.5, label: "Calisthenics modéré", labelEn: "Calisthenics, moderate" },
+
+  // Other endurance & sports
+  { id: "other-row", category: "other", met: 7.0, label: "Aviron modéré", labelEn: "Rowing, moderate" },
+  { id: "other-row-vig", category: "other", met: 8.5, label: "Aviron soutenu", labelEn: "Rowing, vigorous" },
+  { id: "other-rope", category: "other", met: 12.3, label: "Corde à sauter", labelEn: "Jump rope" },
+  { id: "other-yoga", category: "other", met: 2.5, label: "Yoga (Hatha)", labelEn: "Yoga (Hatha)" },
+  { id: "other-yoga-vin", category: "other", met: 4.0, label: "Yoga (Vinyasa / Power)", labelEn: "Yoga (Vinyasa / Power)" },
+  { id: "other-pilates", category: "other", met: 3.0, label: "Pilates", labelEn: "Pilates" },
+  { id: "other-elliptical", category: "other", met: 5.0, label: "Vélo elliptique modéré", labelEn: "Elliptical, moderate" },
+  { id: "other-ski", category: "other", met: 9.0, label: "Ski de fond", labelEn: "Cross-country skiing" },
+  { id: "other-tennis", category: "other", met: 7.3, label: "Tennis (simple)", labelEn: "Tennis (singles)" },
+  { id: "other-football", category: "other", met: 7.0, label: "Football", labelEn: "Soccer" },
+  { id: "other-basket", category: "other", met: 6.5, label: "Basketball", labelEn: "Basketball" },
+  { id: "other-climb", category: "other", met: 8.0, label: "Escalade", labelEn: "Rock climbing" },
+];
+
+export const CATEGORY_ORDER: MetCategory[] = [
+  "running",
+  "cycling",
+  "swimming",
+  "walking",
+  "strength",
+  "other",
+];
+
+/**
+ * Compute energy expenditure for a given MET value, body weight and duration.
+ * @param met MET value of the activity
+ * @param weightKg Body weight in kilograms
+ * @param durationMin Duration in minutes
+ * @returns Energy expended in kilocalories (kcal)
+ */
+export function computeCalories(met: number, weightKg: number, durationMin: number): number {
+  if (met <= 0 || weightKg <= 0 || durationMin <= 0) return 0;
+  return met * weightKg * (durationMin / 60);
+}
+
+/**
+ * Approximate oxygen consumption (VO₂) for a given MET value.
+ * 1 MET = 3.5 ml O₂ / kg / min.
+ */
+export function computeVO2(met: number): number {
+  return met * 3.5;
+}
+
+/**
+ * Intensity classification per the Compendium of Physical Activities:
+ *   < 3 MET  → light
+ *   3–6 MET  → moderate
+ *   ≥ 6 MET  → vigorous
+ */
+export type MetIntensity = "light" | "moderate" | "vigorous";
+
+export function classifyIntensity(met: number): MetIntensity {
+  if (met < 3) return "light";
+  if (met < 6) return "moderate";
+  return "vigorous";
+}

--- a/src/pages/CalculateursPage.tsx
+++ b/src/pages/CalculateursPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Target, Gauge, RefreshCw, Route, Timer, ArrowRight, List, Shuffle, Star, Flag, Scale, Zap, Waves } from "@/components/icons";
+import { Target, Gauge, RefreshCw, Route, Timer, ArrowRight, List, Shuffle, Star, Flag, Scale, Zap, Waves, Flame } from "@/components/icons";
 import type { IconProps } from "@/components/icons";
 import { SEOHead } from "@/components/seo";
 import { cn } from "@/lib/utils";
@@ -164,6 +164,18 @@ const CALCULATEURS: CalculateurEntry[] = [
     gradient: "from-primary/10 dark:from-primary/20",
     iconBg: "bg-primary/15",
     iconColor: "text-primary",
+  },
+  {
+    id: "met",
+    icon: Flame,
+    title: "Calories & équivalent métabolique (MET)",
+    titleEn: "Calories & Metabolic Equivalent (MET)",
+    description: "Estimez la dépense calorique d'une séance à partir de la valeur MET",
+    descriptionEn: "Estimate the calorie expenditure of a session from the MET value",
+    href: "/calculators/met",
+    gradient: "from-zone-5/10 dark:from-zone-5/20",
+    iconBg: "bg-zone-5/15",
+    iconColor: "text-zone-5",
   },
 ];
 

--- a/src/pages/GuidesPage.tsx
+++ b/src/pages/GuidesPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Utensils, Target, Flame, ArrowRight } from "@/components/icons";
+import { Utensils, Target, Flame, Activity, ArrowRight } from "@/components/icons";
 import type { IconProps } from "@/components/icons";
 import { Card, CardContent } from "@/components/ui/card";
 import { SEOHead } from "@/components/seo";
@@ -35,6 +35,13 @@ const GUIDES: GuideEntry[] = [
     titleKey: "warmup.title",
     descriptionKey: "warmup.description",
     href: "/guides/warmup",
+  },
+  {
+    id: "met",
+    icon: Activity,
+    titleKey: "met.title",
+    descriptionKey: "met.description",
+    href: "/guides/met",
   },
 ];
 
@@ -73,7 +80,7 @@ export function GuidesPage() {
         </div>
 
         {/* Guide Cards */}
-        <div className={cn("grid gap-4", "grid-cols-1 md:grid-cols-3")}>
+        <div className={cn("grid gap-4", "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4")}>
           {GUIDES.map((guide) => {
             const Icon = guide.icon;
             return (

--- a/src/pages/MetCalculatorPage.tsx
+++ b/src/pages/MetCalculatorPage.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { Flame, BookOpen } from "@/components/icons";
+import { MetCalculator } from "@/components/domain/MetCalculator";
+import { SEOHead } from "@/components/seo";
+
+export function MetCalculatorPage() {
+  const { t } = useTranslation("common");
+
+  return (
+    <>
+      <SEOHead
+        title={t("calculators:calculateurs.met.seoTitle")}
+        description={t("calculators:calculateurs.met.seoDescription")}
+        canonical="/calculators/met"
+        jsonLd={[
+          {
+            "@type": "WebApplication",
+            name: t("calculators:calculateurs.met.seoAppName"),
+            description: t("calculators:calculateurs.met.seoAppDescription"),
+            url: "https://zoned.run/calculators/met",
+            applicationCategory: "HealthApplication",
+          },
+          {
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              { "@type": "ListItem", position: 1, name: "Accueil", item: "https://zoned.run/" },
+              { "@type": "ListItem", position: 2, name: t("calculators:calculateurs.breadcrumb"), item: "https://zoned.run/calculators" },
+              { "@type": "ListItem", position: 3, name: t("calculators:calculateurs.met.seoBreadcrumb") },
+            ],
+          },
+        ]}
+      />
+      <div className="py-8 max-w-3xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
+            <Flame className="size-8 text-primary" />
+            {t("calculators:calculateurs.met.title")}
+          </h1>
+          <p className="text-muted-foreground text-lg">
+            {t("calculators:calculateurs.met.description")}
+          </p>
+          <Link
+            to="/guides/met"
+            className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline mt-3"
+          >
+            <BookOpen className="size-4" />
+            {t("calculators:calculateurs.met.readGuide")}
+          </Link>
+        </div>
+
+        <MetCalculator />
+      </div>
+    </>
+  );
+}

--- a/src/pages/MetGuidePage.tsx
+++ b/src/pages/MetGuidePage.tsx
@@ -1,0 +1,209 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import {
+  Flame,
+  Info,
+  Calculator,
+  Activity,
+  List,
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  ExternalLink,
+} from "@/components/icons";
+import type { IconProps } from "@/components/icons";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { SEOHead } from "@/components/seo";
+import { GlossaryLinkedText } from "@/components/domain/GlossaryLinkedText";
+import { metSections } from "@/data/guides/met";
+import type { MetBlock } from "@/data/guides/met";
+import { pickLang } from "@/lib/i18n-utils";
+
+const SECTION_ICONS: Record<string, React.ComponentType<IconProps>> = {
+  Info,
+  Calculator,
+  Activity,
+  List,
+  AlertTriangle,
+  Flame,
+};
+
+export function MetGuidePage() {
+  const { t } = useTranslation("guides");
+
+  function renderBlock(block: MetBlock, blockIdx: number) {
+    const text = pickLang(block, "text");
+
+    switch (block.type) {
+      case "paragraph":
+        return (
+          <p key={blockIdx} className="text-muted-foreground leading-relaxed">
+            <GlossaryLinkedText text={text ?? ""} />
+          </p>
+        );
+
+      case "list":
+        return (
+          <div key={blockIdx} className="space-y-2">
+            {text && <h4 className="font-medium text-sm">{text}</h4>}
+            <ul className="space-y-1.5 ml-1">
+              {block.items?.map((item, i) => (
+                <li key={i} className="flex gap-2 text-sm text-muted-foreground">
+                  <span className="text-primary mt-1 shrink-0">&#8226;</span>
+                  <span>{pickLang(item, "text")}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+
+      case "tip":
+        return (
+          <div
+            key={blockIdx}
+            className="flex gap-3 rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4"
+          >
+            <Info className="size-5 shrink-0 text-emerald-600 dark:text-emerald-400 mt-0.5" />
+            <p className="text-sm text-emerald-800 dark:text-emerald-200">
+              <GlossaryLinkedText text={text ?? ""} />
+            </p>
+          </div>
+        );
+
+      case "warning":
+        return (
+          <div
+            key={blockIdx}
+            className="flex gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4"
+          >
+            <AlertTriangle className="size-5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+            <p className="text-sm text-amber-800 dark:text-amber-200">
+              <GlossaryLinkedText text={text ?? ""} />
+            </p>
+          </div>
+        );
+
+      case "formula":
+        return (
+          <div
+            key={blockIdx}
+            className="rounded-xl border border-primary/20 bg-primary/5 p-4 text-center"
+          >
+            <code className="text-base font-semibold text-foreground">
+              {block.formula}
+            </code>
+          </div>
+        );
+
+      case "table":
+        return (
+          <div key={blockIdx} className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <tbody>
+                {block.rows?.map((row, i) => (
+                  <tr key={i} className="border-b last:border-b-0 hover:bg-muted/50">
+                    <td className="py-2 px-3 font-medium w-1/3 align-top">
+                      {pickLang(row, "label")}
+                    </td>
+                    <td className="py-2 px-3 text-muted-foreground">
+                      {pickLang(row, "value")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <>
+      <SEOHead
+        title={t("met.title")}
+        description={t("met.seoDescription")}
+        canonical="/guides/met"
+        jsonLd={[
+          {
+            "@type": "Article",
+            name: t("met.seoArticleName"),
+            description: t("met.seoArticleDescription"),
+            url: "https://zoned.run/guides/met",
+          },
+          {
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              { "@type": "ListItem", position: 1, name: t("home"), item: "https://zoned.run/" },
+              { "@type": "ListItem", position: 2, name: "Guides", item: "https://zoned.run/guides" },
+              { "@type": "ListItem", position: 3, name: t("met.title") },
+            ],
+          },
+        ]}
+      />
+      <div className="py-8">
+        {/* Back link */}
+        <Link
+          to="/guides"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="size-4" />
+          {t("backToGuides")}
+        </Link>
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
+            <Flame className="size-8 text-primary" />
+            {t("met.title")}
+          </h1>
+          <p className="text-muted-foreground text-lg">{t("met.subtitle")}</p>
+          <div className="flex flex-wrap gap-3 mt-4">
+            <Link
+              to="/calculators/met"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              {t("met.openCalculator")}
+              <ArrowRight className="size-4" />
+            </Link>
+            <a
+              href="https://fr.wikipedia.org/wiki/%C3%89quivalent_m%C3%A9tabolique"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t("met.wikipediaLink")}
+              <ExternalLink className="size-3.5" />
+            </a>
+          </div>
+        </div>
+
+        {/* Sections */}
+        <Tabs defaultValue={metSections[0].id}>
+          <TabsList className="flex-wrap h-auto gap-1 mb-6">
+            {metSections.map((section) => {
+              const Icon = SECTION_ICONS[section.icon] ?? Info;
+              return (
+                <TabsTrigger key={section.id} value={section.id} className="gap-1.5">
+                  <Icon className="size-3.5" />
+                  <span className="hidden sm:inline">{pickLang(section, "title")}</span>
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+
+          {metSections.map((section) => (
+            <TabsContent key={section.id} value={section.id}>
+              <div className="space-y-6">
+                <h2 className="text-xl font-semibold">{pickLang(section, "title")}</h2>
+                {section.content.map((block, i) => renderBlock(block, i))}
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
New /calculators/met estimates calorie expenditure via the Compendium of
Physical Activities formula (kcal = MET × kg × hours), with two input
modes: a 40+ activity picker grouped by category (running, cycling,
swimming, walking, strength, other) and a free MET value input.

New /guides/met explains the MET concept (definition, formula, intensity
classification, reference values, limits) and links to the Wikipedia
article. Both pages are cross-linked.

Wired into the calculators hub, guides hub, App router and i18n FR/EN.