### PR TITLE
feat(session): aérer la page de détail d'une séance (lisibilité mobile)

### DIFF
--- a/src/components/domain/WorkoutStructure.tsx
+++ b/src/components/domain/WorkoutStructure.tsx
@@ -60,9 +60,9 @@ export function WorkoutStructure({ workout, userZones, className }: WorkoutStruc
   ].filter((phase) => phase.steps.length > 0);
 
   return (
-    <div className={cn("space-y-5", className)}>
+    <div className={cn("space-y-7 sm:space-y-8", className)}>
       {phases.map((phase) => (
-        <section key={phase.key} className="space-y-2.5">
+        <section key={phase.key} className="space-y-3">
           <div className="space-y-1">
             <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
               {phase.label}
@@ -335,7 +335,7 @@ function SegmentSummaryRow({
 
   return (
     <div className={cn(
-      "rounded-lg border border-border/40 bg-background/80 p-2.5 space-y-1.5",
+      "rounded-lg border border-border/40 bg-background/80 p-3 space-y-1.5",
       muted && "bg-muted/35",
       dashed && "border-dashed border-border/50 bg-muted/20",
     )}>

--- a/src/components/visualization/ZoneDistribution.tsx
+++ b/src/components/visualization/ZoneDistribution.tsx
@@ -25,16 +25,16 @@ export function ZoneDistribution({ workout, className }: ZoneDistributionProps) 
   return (
     <div className={cn("space-y-3", className)}>
       {/* Horizontal bars */}
-      <div className="space-y-2">
+      <div className="space-y-3">
         {zoneBreakdown.map((item) => (
-          <div key={item.zone} className="space-y-1">
+          <div key={item.zone} className="space-y-1.5">
             <div className="flex items-center justify-between text-xs">
               <span className="font-medium">Z{item.zone} - {item.label}</span>
               <span className="text-muted-foreground">
                 {Math.round(item.percent)}% ({formatDurationMinutes(item.durationMin)})
               </span>
             </div>
-            <div className="h-2 rounded-full bg-muted overflow-hidden">
+            <div className="h-2.5 rounded-full bg-muted overflow-hidden">
               <div
                 className="h-full rounded-full transition-all"
                 style={{

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -377,7 +377,7 @@ export function WorkoutDetailPage() {
           },
         ]}
       />
-      <div className={`zone-${dominantZone} py-6 md:py-8 space-y-8`}>
+      <div className={`zone-${dominantZone} py-6 md:py-8 space-y-10 sm:space-y-12 md:space-y-16`}>
         {/* Top strip — back, breadcrumb, optional plan chip. */}
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between gap-3 flex-wrap">
@@ -503,7 +503,7 @@ export function WorkoutDetailPage() {
           {/* Inline stats row — single horizontal strip. Trail metrics
               fold in naturally when applicable so we don't need a
               separate trail bar. */}
-          <dl className="mt-6 grid grid-cols-3 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-8 gap-y-3 border-t border-border/60 pt-5">
+          <dl className="mt-6 grid grid-cols-2 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-8 gap-x-4 gap-y-5 sm:gap-y-3 border-t border-border/60 pt-6">
             <HeroStat
               label={t("session:stats.duration")}
               value={formatDurationMinutes(duration)}
@@ -601,7 +601,7 @@ export function WorkoutDetailPage() {
         {/* Zone distribution + coaching tips paired in a compact 2-col on
             md+, stacked on mobile. */}
         <FadeUp as="section">
-          <div className="grid md:grid-cols-[2fr_3fr] gap-6 md:gap-10">
+          <div className="grid md:grid-cols-[2fr_3fr] gap-8 md:gap-10">
             <div>
               <p className="font-mono text-[10px] tracking-[0.16em] uppercase text-muted-foreground mb-3">
                 {t("session:titles.zoneDistribution")}


### PR DESCRIPTION
Augmente le rythme vertical entre sections, passe la grille de stats du
hero en 2 colonnes sur mobile, et espace les blocs de structure et la
répartition par zone pour une lecture plus claire sur petit écran.

https://claude.ai/code/session_01VYJuv3A8S9R5w4SSCtNrcW