### PR TITLE
feat(library): add "Tirer une séance" (draw a session) page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 // All pages lazy loaded for optimal code-splitting
 const HomePage = lazy(() => import("@/pages/HomePage").then(m => ({ default: m.HomePage })));
 const LibraryPage = lazy(() => import("@/pages/LibraryPage").then(m => ({ default: m.LibraryPage })));
+const DrawSessionPage = lazy(() => import("@/pages/DrawSessionPage").then(m => ({ default: m.DrawSessionPage })));
 const WorkoutDetailPage = lazy(() => import("@/pages/WorkoutDetailPage").then(m => ({ default: m.WorkoutDetailPage })));
 const MyZonesPage = lazy(() => import("@/pages/MyZonesPage").then(m => ({ default: m.MyZonesPage })));
 const FavoritesPage = lazy(() => import("@/pages/FavoritesPage").then(m => ({ default: m.FavoritesPage })));
@@ -248,6 +249,7 @@ function App() {
                         <Routes>
                           <Route path="/" element={<HomePage />} />
                           <Route path="/library" element={<LibraryPage />} />
+                          <Route path="/library/draw" element={<DrawSessionPage />} />
                           <Route path="/workout/builder" element={<WorkoutBuilderPage />} />
                           <Route path="/workout/builder/:id" element={<WorkoutBuilderPage />} />
                           <Route path="/workout/:id" element={<WorkoutDetailPage />} />

--- a/src/components/domain/WorkoutCard.tsx
+++ b/src/components/domain/WorkoutCard.tsx
@@ -20,8 +20,9 @@ import {
 } from "@/components/icons";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ZoneBadge } from "./ZoneBadge";
+import { ZoneBadge, ZoneBadges } from "./ZoneBadge";
 import { FavoriteButton } from "./FavoriteButton";
+import { getWorkoutZones } from "@/lib/landing-stats";
 import {
   SessionIntensityBar,
   transformSessionBlocks,
@@ -78,8 +79,49 @@ export function WorkoutCard({ workout, className, expanded }: WorkoutCardProps) 
   return <RunningWorkoutCard workout={workout} className={className} expanded={expanded} />;
 }
 
-/** Internal running-only card with properly typed props */
-function RunningWorkoutCard({ workout, className, expanded }: { workout: WorkoutTemplate; className?: string; expanded?: boolean }) {
+/**
+ * Shared presentational shell for a running-family workout (running, cycling,
+ * swimming). Renders the visual chrome — zone gradient, title, description,
+ * intensity bar, duration/category line — and exposes slots so the same card
+ * can serve both the library grid (wrapped in a Link, with favourite + peek)
+ * and the "draw a session" result (no link, with an eyebrow, zone badges, a
+ * metrics grid and action buttons).
+ *
+ * Defaults reproduce the original library card exactly, so existing call sites
+ * keep their behaviour without passing any new prop.
+ */
+interface WorkoutCardChromeProps {
+  workout: WorkoutTemplate;
+  className?: string;
+  expanded?: boolean;
+  /** Hover affordance — keep on when the card is wrapped in a link. */
+  interactive?: boolean;
+  /** Content rendered above the title (e.g. discipline · method · n°). */
+  eyebrow?: React.ReactNode;
+  /** Content rendered at the bottom of the card (e.g. action buttons). */
+  actions?: React.ReactNode;
+  /** Content rendered in place of the terrain/difficulty badge row. */
+  metrics?: React.ReactNode;
+  /** Show the zone badges for every zone the workout touches. */
+  showZoneBadges?: boolean;
+  showFavorite?: boolean;
+  showPeek?: boolean;
+  showBadges?: boolean;
+}
+
+export function WorkoutCardChrome({
+  workout,
+  className,
+  expanded,
+  interactive = true,
+  eyebrow,
+  actions,
+  metrics,
+  showZoneBadges = false,
+  showFavorite = true,
+  showPeek = true,
+  showBadges = true,
+}: WorkoutCardChromeProps) {
   const { t } = useTranslation(["library", "common"]);
   const pick = usePickLang();
   const dominantZone = getDominantZone(workout);
@@ -105,48 +147,58 @@ function RunningWorkoutCard({ workout, className, expanded }: { workout: Workout
     trailMetrics.totalElevationLossM > 0 ||
     trailMetrics.dominantTerrain != null;
 
+  const zones = useMemo(
+    () => (showZoneBadges ? getWorkoutZones(workout) : []),
+    [showZoneBadges, workout],
+  );
+
   return (
-    <Link to={`/workout/${workout.id}`}>
-      <Card
-        interactive
-        size="compact"
-        className={cn(
-          `zone-${dominantZone} bg-gradient-to-br from-zone-${dominantZone}/10 dark:from-zone-${dominantZone}/20 to-transparent`,
-          "border-border/50",
-          "overflow-hidden h-full flex flex-col",
-          className
+    <Card
+      interactive={interactive}
+      size="compact"
+      className={cn(
+        `zone-${dominantZone} bg-gradient-to-br from-zone-${dominantZone}/10 dark:from-zone-${dominantZone}/20 to-transparent`,
+        "border-border/50",
+        "overflow-hidden h-full flex flex-col",
+        className
+      )}
+    >
+      <CardHeader className={cn("pb-1.5 sm:pb-2 px-3 sm:px-4", expanded && "pb-2 px-4")}>
+        {eyebrow && <div className="mb-1">{eyebrow}</div>}
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className={cn("text-sm sm:text-base line-clamp-2 sm:line-clamp-1 flex-1", expanded && "text-base line-clamp-none")}>
+            {pick(workout, "name")}
+          </CardTitle>
+          <div className="flex items-center gap-1">
+            {showFavorite && <FavoriteButton workoutId={workout.id} size="sm" />}
+            <ZoneBadge zone={dominantZone} size="sm" />
+          </div>
+        </div>
+        <p className={cn("hidden sm:block text-muted-foreground text-sm line-clamp-2", expanded && "block")}>
+          {pick(workout, "description")}
+        </p>
+      </CardHeader>
+
+      <CardContent className={cn("px-3 sm:px-4 pt-0 mt-auto space-y-2 sm:space-y-3", expanded && "px-4 space-y-3")}>
+        {/* Intensity bar showing zone distribution */}
+        <SessionIntensityBar workout={workout} />
+
+        <div className={cn("flex items-center gap-2 sm:gap-3 text-xs sm:text-sm text-muted-foreground", expanded && "gap-3 text-sm")}>
+          <div className="flex items-center gap-1">
+            <Clock className="size-3.5" />
+            <span>{formatDurationMinutes(duration)}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <CategoryIcon className="size-3.5" />
+            <span>{t(`categories.${workout.category}`)}</span>
+          </div>
+        </div>
+
+        {showZoneBadges && zones.length > 0 && (
+          <ZoneBadges zones={zones} size="sm" />
         )}
-      >
-        <CardHeader className={cn("pb-1.5 sm:pb-2 px-3 sm:px-4", expanded && "pb-2 px-4")}>
-          <div className="flex items-start justify-between gap-2">
-            <CardTitle className={cn("text-sm sm:text-base line-clamp-2 sm:line-clamp-1 flex-1", expanded && "text-base line-clamp-none")}>
-              {pick(workout, "name")}
-            </CardTitle>
-            <div className="flex items-center gap-1">
-              <FavoriteButton workoutId={workout.id} size="sm" />
-              <ZoneBadge zone={dominantZone} size="sm" />
-            </div>
-          </div>
-          <p className={cn("hidden sm:block text-muted-foreground text-sm line-clamp-2", expanded && "block")}>
-            {pick(workout, "description")}
-          </p>
-        </CardHeader>
 
-        <CardContent className={cn("px-3 sm:px-4 pt-0 mt-auto space-y-2 sm:space-y-3", expanded && "px-4 space-y-3")}>
-          {/* Intensity bar showing zone distribution */}
-          <SessionIntensityBar workout={workout} />
-
-          <div className={cn("flex items-center gap-2 sm:gap-3 text-xs sm:text-sm text-muted-foreground", expanded && "gap-3 text-sm")}>
-            <div className="flex items-center gap-1">
-              <Clock className="size-3.5" />
-              <span>{formatDurationMinutes(duration)}</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <CategoryIcon className="size-3.5" />
-              <span>{t(`categories.${workout.category}`)}</span>
-            </div>
-          </div>
-
+        {showBadges && (
           <div className={cn("hidden sm:flex flex-wrap items-center gap-1.5", expanded && "flex")}>
             <Badge variant="secondary" className="text-xs whitespace-nowrap">
               <Dumbbell className="size-3 mr-1" />
@@ -181,49 +233,63 @@ function RunningWorkoutCard({ workout, className, expanded }: { workout: Workout
               </Badge>
             )}
           </div>
+        )}
 
-          {/* Always-visible peek preview */}
-          {peekData.segments.length > 0 && (
-            <div className="border-t border-border/30 pt-2 mt-1 space-y-1.5">
-              {/* Compact session timeline bar */}
-              <div className={cn("flex items-end rounded-md overflow-hidden", isMobile ? "h-4" : "h-6")}>
-                {peekData.segments.map((seg, i) => {
-                  const zoneColor = seg.zoneNumber
-                    ? ZONE_COLORS[seg.zoneNumber]
-                    : "var(--muted-foreground)";
-                  const heightPct = seg.zoneNumber
-                    ? 30 + (seg.zoneNumber - 1) * 14
-                    : 40;
-                  return (
-                    <div
-                      key={seg.id}
-                      className={cn(
-                        "relative",
-                        seg.isRecovery && "opacity-50",
-                      )}
-                      style={{
-                        width: `${seg.widthPercent}%`,
-                        height: `${heightPct}%`,
-                        backgroundColor: zoneColor,
-                        marginLeft: i > 0 ? "1px" : undefined,
-                      }}
-                    />
-                  );
-                })}
-              </div>
-              {/* One-line summary of main set */}
-              {!isMobile && peekData.summary && (
-                <p className="text-xs text-muted-foreground truncate">
-                  {peekData.summary}
-                </p>
-              )}
-              {hasTrail && (
-                <MiniElevationProfile workout={workout} height={28} />
-              )}
+        {/* Optional metrics grid (draw result) */}
+        {metrics}
+
+        {/* Always-visible peek preview */}
+        {showPeek && peekData.segments.length > 0 && (
+          <div className="border-t border-border/30 pt-2 mt-1 space-y-1.5">
+            {/* Compact session timeline bar */}
+            <div className={cn("flex items-end rounded-md overflow-hidden", isMobile ? "h-4" : "h-6")}>
+              {peekData.segments.map((seg, i) => {
+                const zoneColor = seg.zoneNumber
+                  ? ZONE_COLORS[seg.zoneNumber]
+                  : "var(--muted-foreground)";
+                const heightPct = seg.zoneNumber
+                  ? 30 + (seg.zoneNumber - 1) * 14
+                  : 40;
+                return (
+                  <div
+                    key={seg.id}
+                    className={cn(
+                      "relative",
+                      seg.isRecovery && "opacity-50",
+                    )}
+                    style={{
+                      width: `${seg.widthPercent}%`,
+                      height: `${heightPct}%`,
+                      backgroundColor: zoneColor,
+                      marginLeft: i > 0 ? "1px" : undefined,
+                    }}
+                  />
+                );
+              })}
             </div>
-          )}
-        </CardContent>
-      </Card>
+            {/* One-line summary of main set */}
+            {!isMobile && peekData.summary && (
+              <p className="text-xs text-muted-foreground truncate">
+                {peekData.summary}
+              </p>
+            )}
+            {hasTrail && (
+              <MiniElevationProfile workout={workout} height={28} />
+            )}
+          </div>
+        )}
+
+        {actions && <div className="pt-1">{actions}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Internal running-only card with properly typed props */
+function RunningWorkoutCard({ workout, className, expanded }: { workout: WorkoutTemplate; className?: string; expanded?: boolean }) {
+  return (
+    <Link to={`/workout/${workout.id}`}>
+      <WorkoutCardChrome workout={workout} className={className} expanded={expanded} />
     </Link>
   );
 }

--- a/src/components/domain/WorkoutCard.tsx
+++ b/src/components/domain/WorkoutCard.tsx
@@ -81,8 +81,8 @@ export function WorkoutCard({ workout, className, expanded }: WorkoutCardProps) 
 
 /**
  * Shared presentational shell for a running-family workout (running, cycling,
- * swimming). Renders the visual chrome — zone gradient, title, description,
- * intensity bar, duration/category line — and exposes slots so the same card
+ * swimming). Renders the visual chrome (zone gradient, title, description,
+ * intensity bar, duration/category line) and exposes slots so the same card
  * can serve both the library grid (wrapped in a Link, with favourite + peek)
  * and the "draw a session" result (no link, with an eyebrow, zone badges, a
  * metrics grid and action buttons).
@@ -94,7 +94,7 @@ interface WorkoutCardChromeProps {
   workout: WorkoutTemplate;
   className?: string;
   expanded?: boolean;
-  /** Hover affordance — keep on when the card is wrapped in a link. */
+  /** Hover affordance: keep on when the card is wrapped in a link. */
   interactive?: boolean;
   /** Content rendered above the title (e.g. discipline · method · n°). */
   eyebrow?: React.ReactNode;

--- a/src/components/domain/WorkoutCard.tsx
+++ b/src/components/domain/WorkoutCard.tsx
@@ -98,9 +98,7 @@ interface WorkoutCardChromeProps {
   interactive?: boolean;
   /** Content rendered above the title (e.g. discipline · method · n°). */
   eyebrow?: React.ReactNode;
-  /** Content rendered at the bottom of the card (e.g. action buttons). */
-  actions?: React.ReactNode;
-  /** Content rendered in place of the terrain/difficulty badge row. */
+  /** Content rendered after the badge row (e.g. a metrics grid). */
   metrics?: React.ReactNode;
   /** Show the zone badges for every zone the workout touches. */
   showZoneBadges?: boolean;
@@ -115,7 +113,6 @@ export function WorkoutCardChrome({
   expanded,
   interactive = true,
   eyebrow,
-  actions,
   metrics,
   showZoneBadges = false,
   showFavorite = true,
@@ -278,8 +275,6 @@ export function WorkoutCardChrome({
             )}
           </div>
         )}
-
-        {actions && <div className="pt-1">{actions}</div>}
       </CardContent>
     </Card>
   );

--- a/src/components/domain/WorkoutFilters.tsx
+++ b/src/components/domain/WorkoutFilters.tsx
@@ -82,7 +82,7 @@ interface WorkoutFiltersProps {
 }
 
 const DURATION_MIN = 0;
-const DURATION_MAX = 240;
+const DURATION_MAX = 300;
 
 /* ── Chip / tag button ── */
 function FilterChip({

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -1,5 +1,5 @@
 export { ZoneBadge, ZoneBadges } from "./ZoneBadge";
-export { WorkoutCard, WorkoutCardCompact } from "./WorkoutCard";
+export { WorkoutCard, WorkoutCardCompact, WorkoutCardChrome } from "./WorkoutCard";
 export { WorkoutListItem } from "./WorkoutListItem";
 export { StrengthWorkoutCard, StrengthWorkoutCardCompact, StrengthWorkoutListItem } from "./StrengthWorkoutCard";
 export { ViewModeSelector } from "./ViewModeSelector";

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -79,6 +79,7 @@ export const PRIMARY_NAV: NavSection[] = [
     prefix: ["/library", "/workout", "/collections"],
     children: [
       { to: "/library", labelKey: "topnav.libraryAll", descKey: "topnav.libraryAllDesc" },
+      { to: "/library/draw", labelKey: "topnav.drawSession", descKey: "topnav.drawSessionDesc" },
       { to: "/collections", labelKey: "topnav.collections", descKey: "topnav.collectionsDesc" },
       { to: "/workout/builder", labelKey: "topnav.builder", descKey: "topnav.builderDesc" },
     ],

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -688,7 +688,7 @@
     "title": "Table of contents"
   },
   "seo": {
-    "drawTitle": "Draw a session — Zoned",
+    "drawTitle": "Draw a session",
     "contribute": "Contribute",
     "contributeDesc": "Share your favorite training sessions with the Zoned community",
     "quiz": "Workout Quiz",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -291,6 +291,8 @@
     "account": "Account",
     "libraryAll": "All sessions",
     "libraryAllDesc": "Running, cycling, swimming, strength",
+    "drawSession": "Draw a session",
+    "drawSessionDesc": "Let chance pick your session",
     "collections": "Collections",
     "collectionsDesc": "Sessions grouped by theme",
     "builder": "Create a session",
@@ -563,6 +565,10 @@
     }
   },
   "hints": {
+    "draw": {
+      "title": "Let chance decide",
+      "description": "Filter by discipline, zone, duration and level, then draw a session from the catalogue."
+    },
     "planCalendar": {
       "title": "Organize your plan",
       "description": "Drag a session to another day. Long press or right-click to view, delete or reorder."
@@ -682,6 +688,7 @@
     "title": "Table of contents"
   },
   "seo": {
+    "drawTitle": "Draw a session — Zoned",
     "contribute": "Contribute",
     "contributeDesc": "Share your favorite training sessions with the Zoned community",
     "quiz": "Workout Quiz",

--- a/src/i18n/locales/en/library.json
+++ b/src/i18n/locales/en/library.json
@@ -141,7 +141,7 @@
     },
     "placeholder": {
       "title": "Ready to draw?",
-      "description": "Set your filters on the left, then draw a session — or let chance decide."
+      "description": "Set your filters on the left, then draw a session, or let chance decide."
     },
     "empty": {
       "title": "No session matches",

--- a/src/i18n/locales/en/library.json
+++ b/src/i18n/locales/en/library.json
@@ -95,5 +95,58 @@
   "noResults": "No workouts match your criteria",
   "clearFilters": "Clear filters",
   "showMore": "Show more",
-  "showingCount": "{{visible}} of {{total}} workouts"
+  "showingCount": "{{visible}} of {{total}} workouts",
+  "draw": {
+    "title": "Draw a session",
+    "subtitle": "Let chance pick your next session from the catalogue",
+    "scanning": "Scanning the catalogue…",
+    "draw": "Draw a session",
+    "redraw": "Re-draw",
+    "surprise": "Surprise me (whole catalogue)",
+    "spaceHint": "or press the Space bar",
+    "start": "Start the session",
+    "viewDetail": "View details",
+    "filters": {
+      "title": "Filters",
+      "discipline": "Discipline",
+      "zone": "Goal · target zone",
+      "maxDuration": "Maximum duration",
+      "level": "Level",
+      "reset": "Reset"
+    },
+    "zoneChips": {
+      "1": "Z1 · Recovery",
+      "2": "Z2 · Endurance",
+      "3": "Z3 · Tempo",
+      "4": "Z4 · Threshold",
+      "5": "Z5 · VO₂max",
+      "6": "Z6 · Sprint"
+    },
+    "counter": {
+      "match_one": "session matches",
+      "match_other": "sessions match",
+      "short_one": "{{count}} session",
+      "short_other": "{{count}} sessions",
+      "ofTotal": "of {{total}} in catalogue"
+    },
+    "metrics": {
+      "duration": "Duration",
+      "tss": "TSS",
+      "zone": "Zone",
+      "level": "Level"
+    },
+    "recent": {
+      "title": "Recent draws",
+      "avoidRepeats": "Avoid repeats"
+    },
+    "placeholder": {
+      "title": "Ready to draw?",
+      "description": "Set your filters on the left, then draw a session — or let chance decide."
+    },
+    "empty": {
+      "title": "No session matches",
+      "description": "Widen your filters or reset to draw again.",
+      "reset": "Reset filters"
+    }
+  }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -291,6 +291,8 @@
     "account": "Compte",
     "libraryAll": "Toutes les séances",
     "libraryAllDesc": "Course, vélo, natation, renforcement",
+    "drawSession": "Tirer une séance",
+    "drawSessionDesc": "Laisse le hasard choisir ta séance",
     "collections": "Collections",
     "collectionsDesc": "Séances groupées par thème",
     "builder": "Créer une séance",
@@ -563,6 +565,10 @@
     }
   },
   "hints": {
+    "draw": {
+      "title": "Laisse le hasard décider",
+      "description": "Filtre par discipline, zone, durée et niveau, puis tire une séance dans le catalogue."
+    },
     "planCalendar": {
       "title": "Organisez votre plan",
       "description": "Glissez une séance vers un autre jour. Appui long ou clic droit pour voir, supprimer ou réordonner."
@@ -682,6 +688,7 @@
     "title": "Sommaire"
   },
   "seo": {
+    "drawTitle": "Tirer une séance — Zoned",
     "contribute": "Contribuer",
     "contributeDesc": "Partagez vos séances d'entraînement préférées avec la communauté Zoned",
     "quiz": "Quiz d'entraînement",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -688,7 +688,7 @@
     "title": "Sommaire"
   },
   "seo": {
-    "drawTitle": "Tirer une séance — Zoned",
+    "drawTitle": "Tirer une séance",
     "contribute": "Contribuer",
     "contributeDesc": "Partagez vos séances d'entraînement préférées avec la communauté Zoned",
     "quiz": "Quiz d'entraînement",

--- a/src/i18n/locales/fr/library.json
+++ b/src/i18n/locales/fr/library.json
@@ -95,5 +95,58 @@
   "noResults": "Aucune séance ne correspond à vos critères",
   "clearFilters": "Effacer les filtres",
   "showMore": "Voir plus",
-  "showingCount": "{{visible}} sur {{total}} séances"
+  "showingCount": "{{visible}} sur {{total}} séances",
+  "draw": {
+    "title": "Tirer une séance",
+    "subtitle": "Laisse le hasard choisir ta prochaine séance dans le catalogue",
+    "scanning": "Scan du catalogue…",
+    "draw": "Tirer une séance",
+    "redraw": "Re-tirer",
+    "surprise": "Surprends-moi (tout le catalogue)",
+    "spaceHint": "ou appuie sur la barre Espace",
+    "start": "Lancer la séance",
+    "viewDetail": "Voir le détail",
+    "filters": {
+      "title": "Filtres",
+      "discipline": "Discipline",
+      "zone": "Objectif · zone visée",
+      "maxDuration": "Durée maximale",
+      "level": "Niveau",
+      "reset": "Réinitialiser"
+    },
+    "zoneChips": {
+      "1": "Z1 · Récup",
+      "2": "Z2 · Endurance",
+      "3": "Z3 · Tempo",
+      "4": "Z4 · Seuil",
+      "5": "Z5 · VO₂max / VMA",
+      "6": "Z6 · Sprint"
+    },
+    "counter": {
+      "match_one": "séance correspond",
+      "match_other": "séances correspondent",
+      "short_one": "{{count}} séance",
+      "short_other": "{{count}} séances",
+      "ofTotal": "sur {{total}} au catalogue"
+    },
+    "metrics": {
+      "duration": "Durée",
+      "tss": "TSS",
+      "zone": "Zone",
+      "level": "Niveau"
+    },
+    "recent": {
+      "title": "Tirages récents",
+      "avoidRepeats": "Éviter les répétitions"
+    },
+    "placeholder": {
+      "title": "Prêt à piocher ?",
+      "description": "Règle tes filtres à gauche, puis tire une séance — ou laisse le hasard décider."
+    },
+    "empty": {
+      "title": "Aucune séance ne correspond",
+      "description": "Élargis tes filtres ou réinitialise pour relancer un tirage.",
+      "reset": "Réinitialiser les filtres"
+    }
+  }
 }

--- a/src/i18n/locales/fr/library.json
+++ b/src/i18n/locales/fr/library.json
@@ -141,7 +141,7 @@
     },
     "placeholder": {
       "title": "Prêt à piocher ?",
-      "description": "Règle tes filtres à gauche, puis tire une séance — ou laisse le hasard décider."
+      "description": "Règle tes filtres à gauche, puis tire une séance, ou laisse le hasard décider."
     },
     "empty": {
       "title": "Aucune séance ne correspond",

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -61,8 +61,19 @@ import { cn } from "@/lib/utils";
 // ────────────────────────────────────────────────────────────────────────────
 
 const DURATION_MIN = 25;
-const DURATION_MAX = 150;
-const DURATION_PRESETS = [30, 45, 60, 90, 150] as const;
+const DURATION_MAX = 300; // slider ceiling
+// Sentinel for "no upper limit" (the "+300" preset). A finite value so it
+// serialises cleanly to sessionStorage, unlike Infinity.
+const DURATION_NO_LIMIT = Number.MAX_SAFE_INTEGER;
+const DURATION_PRESETS: { label: string; value: number }[] = [
+  { label: "≤30", value: 30 },
+  { label: "≤45", value: 45 },
+  { label: "≤60", value: 60 },
+  { label: "≤90", value: 90 },
+  { label: "≤150", value: 150 },
+  { label: "≤300", value: 300 },
+  { label: "+300", value: DURATION_NO_LIMIT },
+];
 
 const DISCIPLINES = ["running", "cycling", "swimming", "strength"] as const;
 type DrawDiscipline = (typeof DISCIPLINES)[number];
@@ -133,7 +144,7 @@ interface DrawFilters {
 const defaultFilters: DrawFilters = {
   disciplines: [],
   zones: [],
-  maxDuration: DURATION_MAX,
+  maxDuration: DURATION_NO_LIMIT, // no cap by default (the "+300" preset)
   levels: [],
 };
 
@@ -174,7 +185,7 @@ function isFilterActive(f: DrawFilters): boolean {
     f.disciplines.length > 0 ||
     f.zones.length > 0 ||
     f.levels.length > 0 ||
-    f.maxDuration !== DURATION_MAX
+    f.maxDuration !== DURATION_NO_LIMIT
   );
 }
 
@@ -530,7 +541,7 @@ export function DrawSessionPage() {
               {/* Max duration */}
               <FilterGroup label={t("draw.filters.maxDuration")}>
                 <Slider
-                  value={[filters.maxDuration]}
+                  value={[Math.min(filters.maxDuration, DURATION_MAX)]}
                   min={DURATION_MIN}
                   max={DURATION_MAX}
                   step={5}
@@ -542,27 +553,29 @@ export function DrawSessionPage() {
                 <div className="mt-1.5 flex items-center justify-between text-xs text-muted-foreground">
                   <span>{DURATION_MIN} min</span>
                   <span className="font-semibold text-foreground">
-                    ≤ {filters.maxDuration} min
+                    {filters.maxDuration > DURATION_MAX
+                      ? `+${DURATION_MAX} min`
+                      : `≤ ${filters.maxDuration} min`}
                   </span>
                   <span>{DURATION_MAX} min</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {DURATION_PRESETS.map((p) => (
                     <button
-                      key={p}
+                      key={p.label}
                       type="button"
                       onClick={() =>
-                        setFilters((f) => ({ ...f, maxDuration: p }))
+                        setFilters((f) => ({ ...f, maxDuration: p.value }))
                       }
-                      aria-pressed={filters.maxDuration === p}
+                      aria-pressed={filters.maxDuration === p.value}
                       className={cn(
                         "rounded-md border px-2 py-1 text-xs font-medium transition-colors",
-                        filters.maxDuration === p
+                        filters.maxDuration === p.value
                           ? "border-primary bg-primary/10 text-primary"
                           : "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
                       )}
                     >
-                      ≤{p}
+                      {p.label}
                     </button>
                   ))}
                 </div>

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -777,12 +777,11 @@ function ScanCard({
  * Full result card with profile, zones and metrics.
  *
  * Like a library card, the whole card is a link to the workout detail and
- * carries a favourite toggle — there is no separate "view / launch" button,
- * since tapping the card already opens the session (re-drawing is the big
- * button above). Running-family workouts reuse the shared
- * {@link WorkoutCardChrome}; strength sessions — no aerobic zones / intensity
- * profile, different template type — fall back to a lightweight layout,
- * mirroring how the rest of the app branches on `isStrengthWorkout`.
+ * carries a favourite toggle, plus an explicit "view detail" button below.
+ * Running-family workouts reuse the shared {@link WorkoutCardChrome};
+ * strength sessions (no aerobic zones / intensity profile, different template
+ * type) fall back to a lightweight layout, mirroring how the rest of the app
+ * branches on `isStrengthWorkout`.
  */
 function ResultCard({
   workout,
@@ -829,12 +828,12 @@ function ResultCard({
       <Metric
         icon={Gauge}
         label={t("draw.metrics.tss")}
-        value={tss != null ? String(tss) : "—"}
+        value={tss != null ? String(tss) : "-"}
       />
       <Metric
         icon={Target}
         label={t("draw.metrics.zone")}
-        value={zones.length > 0 ? `Z${dominantZone}` : "—"}
+        value={zones.length > 0 ? `Z${dominantZone}` : "-"}
       />
       <Metric
         icon={Star}
@@ -874,7 +873,7 @@ function ResultCard({
     );
   }
 
-  // Strength fallback — no zones / intensity profile.
+  // Strength fallback (no zones / intensity profile).
   return (
     <div className={animateIn}>
       <Link

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -845,45 +845,56 @@ function ResultCard({
   );
 
   const animateIn =
-    "block motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300";
+    "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300";
+
+  // Explicit "view detail" CTA. Kept outside the card link below to avoid an
+  // anchor nested inside an anchor (the whole card is already a link).
+  const detailAction = (
+    <Button asChild variant="outline" className="mt-3 w-full sm:w-auto">
+      <Link to={`/workout/${workout.id}`}>{t("draw.viewDetail")}</Link>
+    </Button>
+  );
 
   // Running / cycling / swimming → reuse the shared library card chrome.
   if (isRunningWorkout(workout)) {
     return (
-      <Link to={`/workout/${workout.id}`} className={animateIn}>
-        <WorkoutCardChrome
-          workout={workout}
-          eyebrow={eyebrow}
-          metrics={metrics}
-          showZoneBadges
-          showPeek={false}
-          showBadges={false}
-        />
-      </Link>
+      <div className={animateIn}>
+        <Link to={`/workout/${workout.id}`} className="block">
+          <WorkoutCardChrome
+            workout={workout}
+            eyebrow={eyebrow}
+            metrics={metrics}
+            showZoneBadges
+            showPeek={false}
+            showBadges={false}
+          />
+        </Link>
+        {detailAction}
+      </div>
     );
   }
 
   // Strength fallback — no zones / intensity profile.
   return (
-    <Link
-      to={`/workout/${workout.id}`}
-      className={cn(
-        "rounded-xl border border-border p-5 hover:bg-accent/40 transition-colors",
-        animateIn,
-      )}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">{eyebrow}</div>
-        <FavoriteButton workoutId={workout.id} size="sm" />
-      </div>
-      <h3 className="mt-1.5 text-xl font-bold leading-snug">
-        {pick(workout, "name")}
-      </h3>
-      <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
-        {pick(workout, "description")}
-      </p>
-      <div className="mt-4">{metrics}</div>
-    </Link>
+    <div className={animateIn}>
+      <Link
+        to={`/workout/${workout.id}`}
+        className="block rounded-xl border border-border p-5 hover:bg-accent/40 transition-colors"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">{eyebrow}</div>
+          <FavoriteButton workoutId={workout.id} size="sm" />
+        </div>
+        <h3 className="mt-1.5 text-xl font-bold leading-snug">
+          {pick(workout, "name")}
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+          {pick(workout, "description")}
+        </p>
+        <div className="mt-4">{metrics}</div>
+      </Link>
+      {detailAction}
+    </div>
   );
 }
 

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -36,6 +36,7 @@ import {
 import { SEOHead } from "@/components/seo";
 import { EditorialTitle, FadeUp } from "@/components/editorial";
 import { usePageHint } from "@/hooks/usePageHint";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { useWorkouts } from "@/hooks";
 import { useStrengthWorkouts } from "@/hooks/useStrengthWorkouts";
 import { useCrossDisciplineWorkouts } from "@/hooks/useCrossDisciplineWorkouts";
@@ -177,6 +178,7 @@ export function DrawSessionPage() {
   const { t: tStrength } = useTranslation("strength");
   const pick = usePickLang();
   const isEn = i18n.language?.startsWith("en") ?? false;
+  const isMobile = useIsMobile();
 
   const { workouts: running } = useWorkouts();
   const { workouts: strength } = useStrengthWorkouts();
@@ -574,9 +576,11 @@ export function DrawSessionPage() {
                   <Dices className={cn("size-5", isDrawing && "animate-spin")} />
                   {isDrawing ? t("draw.scanning") : t("draw.draw")}
                 </Button>
-                <p className="text-xs text-muted-foreground">
-                  {t("draw.spaceHint")}
-                </p>
+                {!isMobile && (
+                  <p className="text-xs text-muted-foreground">
+                    {t("draw.spaceHint")}
+                  </p>
+                )}
                 {filtersActive && (
                   <button
                     type="button"

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -17,7 +17,6 @@ import {
   Gauge,
   Filter,
   X,
-  ArrowRight,
   Footprints,
   Bike,
   Waves,
@@ -28,6 +27,7 @@ import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { Card } from "@/components/ui/card";
 import { WorkoutCardChrome } from "@/components/domain";
+import { FavoriteButton } from "@/components/domain/FavoriteButton";
 import {
   getWorkoutDuration,
   formatDurationMinutes,
@@ -573,7 +573,11 @@ export function DrawSessionPage() {
                   className="h-14 px-8 text-base w-full sm:w-auto"
                 >
                   <Dices className={cn("size-5", isDrawing && "animate-spin")} />
-                  {isDrawing ? t("draw.scanning") : t("draw.draw")}
+                  {isDrawing
+                    ? t("draw.scanning")
+                    : result
+                      ? t("draw.redraw")
+                      : t("draw.draw")}
                 </Button>
                 {!isMobile && (
                   <p className="text-xs text-muted-foreground">
@@ -605,8 +609,6 @@ export function DrawSessionPage() {
                     pick={pick}
                     t={t}
                     tStrength={tStrength}
-                    onRedraw={handleDraw}
-                    isDrawing={isDrawing}
                   />
                 ) : (
                   <Placeholder t={t} />
@@ -772,28 +774,26 @@ function ScanCard({
 }
 
 /**
- * Full result card with profile, zones, metrics and actions.
+ * Full result card with profile, zones and metrics.
  *
- * Running-family workouts reuse the shared {@link WorkoutCardChrome} (same
- * visual shell as the library card) with the draw-specific slots injected.
- * Strength sessions — which have no aerobic zones / intensity profile and a
- * different template type — fall back to a lightweight layout, mirroring how
- * the rest of the app branches on `isStrengthWorkout`.
+ * Like a library card, the whole card is a link to the workout detail and
+ * carries a favourite toggle — there is no separate "view / launch" button,
+ * since tapping the card already opens the session (re-drawing is the big
+ * button above). Running-family workouts reuse the shared
+ * {@link WorkoutCardChrome}; strength sessions — no aerobic zones / intensity
+ * profile, different template type — fall back to a lightweight layout,
+ * mirroring how the rest of the app branches on `isStrengthWorkout`.
  */
 function ResultCard({
   workout,
   pick,
   t,
   tStrength,
-  onRedraw,
-  isDrawing,
 }: {
   workout: AnyWorkoutTemplate;
   pick: ReturnType<typeof usePickLang>;
   t: (k: string, o?: Record<string, unknown>) => string;
   tStrength: (k: string) => string;
-  onRedraw: () => void;
-  isDrawing: boolean;
 }) {
   const isStrength = isStrengthWorkout(workout);
   const discipline = getDrawDiscipline(workout);
@@ -844,55 +844,38 @@ function ResultCard({
     </div>
   );
 
-  const actions = (
-    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-      <Button asChild className="flex-1 sm:flex-none">
-        <Link to={`/workout/${workout.id}`}>
-          {t("draw.start")}
-          <ArrowRight className="size-4" />
-        </Link>
-      </Button>
-      <Button asChild variant="outline" className="flex-1 sm:flex-none">
-        <Link to={`/workout/${workout.id}`}>{t("draw.viewDetail")}</Link>
-      </Button>
-      <Button
-        variant="ghost"
-        onClick={onRedraw}
-        disabled={isDrawing}
-        className="flex-1 sm:flex-none"
-      >
-        <RotateCcw className="size-4" />
-        {t("draw.redraw")}
-      </Button>
-    </div>
-  );
-
   const animateIn =
-    "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300";
+    "block motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300";
 
   // Running / cycling / swimming → reuse the shared library card chrome.
   if (isRunningWorkout(workout)) {
     return (
-      <div className={animateIn}>
+      <Link to={`/workout/${workout.id}`} className={animateIn}>
         <WorkoutCardChrome
           workout={workout}
-          interactive={false}
           eyebrow={eyebrow}
           metrics={metrics}
-          actions={actions}
           showZoneBadges
-          showFavorite={false}
           showPeek={false}
           showBadges={false}
         />
-      </div>
+      </Link>
     );
   }
 
   // Strength fallback — no zones / intensity profile.
   return (
-    <div className={cn("rounded-xl border border-border p-5", animateIn)}>
-      {eyebrow}
+    <Link
+      to={`/workout/${workout.id}`}
+      className={cn(
+        "rounded-xl border border-border p-5 hover:bg-accent/40 transition-colors",
+        animateIn,
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">{eyebrow}</div>
+        <FavoriteButton workoutId={workout.id} size="sm" />
+      </div>
       <h3 className="mt-1.5 text-xl font-bold leading-snug">
         {pick(workout, "name")}
       </h3>
@@ -900,8 +883,7 @@ function ResultCard({
         {pick(workout, "description")}
       </p>
       <div className="mt-4">{metrics}</div>
-      <div className="mt-5">{actions}</div>
-    </div>
+    </Link>
   );
 }
 

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -27,8 +27,7 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { Card } from "@/components/ui/card";
-import { ZoneBadges } from "@/components/domain/ZoneBadge";
-import { SessionIntensityBar } from "@/components/visualization";
+import { WorkoutCardChrome } from "@/components/domain";
 import {
   getWorkoutDuration,
   formatDurationMinutes,
@@ -772,7 +771,15 @@ function ScanCard({
   );
 }
 
-/** Full result card with profile, zones, metrics and actions. */
+/**
+ * Full result card with profile, zones, metrics and actions.
+ *
+ * Running-family workouts reuse the shared {@link WorkoutCardChrome} (same
+ * visual shell as the library card) with the draw-specific slots injected.
+ * Strength sessions — which have no aerobic zones / intensity profile and a
+ * different template type — fall back to a lightweight layout, mirroring how
+ * the rest of the app branches on `isStrengthWorkout`.
+ */
 function ResultCard({
   workout,
   pick,
@@ -791,9 +798,7 @@ function ResultCard({
   const isStrength = isStrengthWorkout(workout);
   const discipline = getDrawDiscipline(workout);
   const DisciplineIcon = DISCIPLINE_ICONS[discipline];
-  const dominantZone = isRunningWorkout(workout)
-    ? getDominantZone(workout)
-    : 2;
+  const dominantZone = isRunningWorkout(workout) ? getDominantZone(workout) : 2;
   const zones = getAnyWorkoutZones(workout);
   const duration = getAnyWorkoutDuration(workout);
   const tss = getAnyWorkoutTss(workout);
@@ -802,90 +807,100 @@ function ResultCard({
     ? tStrength(`categories.${workout.category}`)
     : t(`categories.${workout.category}`);
 
-  return (
-    <div
-      className={cn(
-        "rounded-xl border border-border p-5 motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300",
-        `zone-${dominantZone} bg-gradient-to-br from-zone-${dominantZone}/15 to-transparent`,
-      )}
-    >
-      {/* Eyebrow: discipline · method · n° */}
-      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-        <DisciplineIcon className="size-3.5" />
-        <span>{t(`activityToggle.${discipline}`)}</span>
-        <span aria-hidden="true">·</span>
-        <span>{methodLabel}</span>
-        <span aria-hidden="true">·</span>
-        <span className="tabular-nums">n°{getWorkoutNumber(workout.id)}</span>
-      </div>
+  // Eyebrow: discipline · method · n°
+  const eyebrow = (
+    <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+      <DisciplineIcon className="size-3.5" />
+      <span>{t(`activityToggle.${discipline}`)}</span>
+      <span aria-hidden="true">·</span>
+      <span>{methodLabel}</span>
+      <span aria-hidden="true">·</span>
+      <span className="tabular-nums">n°{getWorkoutNumber(workout.id)}</span>
+    </div>
+  );
 
-      {/* Title */}
+  const metrics = (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Metric
+        icon={Clock}
+        label={t("draw.metrics.duration")}
+        value={formatDurationMinutes(duration)}
+      />
+      <Metric
+        icon={Gauge}
+        label={t("draw.metrics.tss")}
+        value={tss != null ? String(tss) : "—"}
+      />
+      <Metric
+        icon={Target}
+        label={t("draw.metrics.zone")}
+        value={zones.length > 0 ? `Z${dominantZone}` : "—"}
+      />
+      <Metric
+        icon={Star}
+        label={t("draw.metrics.level")}
+        value={t(`difficulty.${workout.difficulty}`)}
+      />
+    </div>
+  );
+
+  const actions = (
+    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+      <Button asChild className="flex-1 sm:flex-none">
+        <Link to={`/workout/${workout.id}`}>
+          {t("draw.start")}
+          <ArrowRight className="size-4" />
+        </Link>
+      </Button>
+      <Button asChild variant="outline" className="flex-1 sm:flex-none">
+        <Link to={`/workout/${workout.id}`}>{t("draw.viewDetail")}</Link>
+      </Button>
+      <Button
+        variant="ghost"
+        onClick={onRedraw}
+        disabled={isDrawing}
+        className="flex-1 sm:flex-none"
+      >
+        <RotateCcw className="size-4" />
+        {t("draw.redraw")}
+      </Button>
+    </div>
+  );
+
+  const animateIn =
+    "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300";
+
+  // Running / cycling / swimming → reuse the shared library card chrome.
+  if (isRunningWorkout(workout)) {
+    return (
+      <div className={animateIn}>
+        <WorkoutCardChrome
+          workout={workout}
+          interactive={false}
+          eyebrow={eyebrow}
+          metrics={metrics}
+          actions={actions}
+          showZoneBadges
+          showFavorite={false}
+          showPeek={false}
+          showBadges={false}
+        />
+      </div>
+    );
+  }
+
+  // Strength fallback — no zones / intensity profile.
+  return (
+    <div className={cn("rounded-xl border border-border p-5", animateIn)}>
+      {eyebrow}
       <h3 className="mt-1.5 text-xl font-bold leading-snug">
         {pick(workout, "name")}
       </h3>
       <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
         {pick(workout, "description")}
       </p>
-
-      {/* Effort profile (aerobic sports only) */}
-      {!isStrength && (
-        <div className="mt-4">
-          <SessionIntensityBar workout={workout} className="h-1.5" />
-        </div>
-      )}
-
-      {/* Zone chips */}
-      {zones.length > 0 && (
-        <div className="mt-3">
-          <ZoneBadges zones={zones} size="sm" />
-        </div>
-      )}
-
-      {/* 4 metrics */}
-      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Metric
-          icon={Clock}
-          label={t("draw.metrics.duration")}
-          value={formatDurationMinutes(duration)}
-        />
-        <Metric
-          icon={Gauge}
-          label={t("draw.metrics.tss")}
-          value={tss != null ? String(tss) : "—"}
-        />
-        <Metric
-          icon={Target}
-          label={t("draw.metrics.zone")}
-          value={zones.length > 0 ? `Z${dominantZone}` : "—"}
-        />
-        <Metric
-          icon={Star}
-          label={t("draw.metrics.level")}
-          value={t(`difficulty.${workout.difficulty}`)}
-        />
-      </div>
-
-      {/* Actions */}
-      <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-        <Button asChild className="flex-1 sm:flex-none">
-          <Link to={`/workout/${workout.id}`}>
-            {t("draw.start")}
-            <ArrowRight className="size-4" />
-          </Link>
-        </Button>
-        <Button asChild variant="outline" className="flex-1 sm:flex-none">
-          <Link to={`/workout/${workout.id}`}>{t("draw.viewDetail")}</Link>
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={onRedraw}
-          disabled={isDrawing}
-          className="flex-1 sm:flex-none"
-        >
-          <RotateCcw className="size-4" />
-          {t("draw.redraw")}
-        </Button>
-      </div>
+      <div className="mt-4">{metrics}</div>
+      <div className="mt-5">{actions}</div>
     </div>
   );
 }

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -1,0 +1,909 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  Dices,
+  Sparkles,
+  RotateCcw,
+  Star,
+  Clock,
+  Target,
+  Gauge,
+  Filter,
+  X,
+  ArrowRight,
+  Footprints,
+  Bike,
+  Waves,
+  Dumbbell,
+} from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { Card } from "@/components/ui/card";
+import { ZoneBadges } from "@/components/domain/ZoneBadge";
+import { SessionIntensityBar } from "@/components/visualization";
+import {
+  getWorkoutDuration,
+  formatDurationMinutes,
+} from "@/components/visualization";
+import { SEOHead } from "@/components/seo";
+import { EditorialTitle, FadeUp } from "@/components/editorial";
+import { usePageHint } from "@/hooks/usePageHint";
+import { useWorkouts } from "@/hooks";
+import { useStrengthWorkouts } from "@/hooks/useStrengthWorkouts";
+import { useCrossDisciplineWorkouts } from "@/hooks/useCrossDisciplineWorkouts";
+import { estimateTSS, getWorkoutZones } from "@/lib/landing-stats";
+import type {
+  AnyWorkoutTemplate,
+  Difficulty,
+  ZoneNumber,
+} from "@/types";
+import {
+  getWorkoutDiscipline,
+  getDominantZone,
+  isStrengthWorkout,
+  isRunningWorkout,
+  DIFFICULTY_META,
+} from "@/types";
+import type { StrengthWorkoutTemplate } from "@/types/strength";
+import { usePickLang } from "@/lib/i18n-utils";
+import { cn } from "@/lib/utils";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Constants & helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+const DURATION_MIN = 25;
+const DURATION_MAX = 150;
+const DURATION_PRESETS = [30, 45, 60, 90, 150] as const;
+
+const DISCIPLINES = ["running", "cycling", "swimming", "strength"] as const;
+type DrawDiscipline = (typeof DISCIPLINES)[number];
+
+const DISCIPLINE_ICONS: Record<
+  DrawDiscipline,
+  React.ComponentType<{ className?: string }>
+> = {
+  running: Footprints,
+  cycling: Bike,
+  swimming: Waves,
+  strength: Dumbbell,
+};
+
+const ZONE_NUMBERS: ZoneNumber[] = [1, 2, 3, 4, 5, 6];
+const LEVELS: Difficulty[] = ["beginner", "intermediate", "advanced", "elite"];
+
+const HISTORY_LIMIT = 5;
+
+/** Resolve the draw-level discipline (strength sits alongside the 3 sports). */
+function getDrawDiscipline(w: AnyWorkoutTemplate): DrawDiscipline {
+  if (isStrengthWorkout(w)) return "strength";
+  return getWorkoutDiscipline(w) as DrawDiscipline;
+}
+
+function getStrengthDuration(w: StrengthWorkoutTemplate): number {
+  return Math.round((w.typicalDuration.min + w.typicalDuration.max) / 2);
+}
+
+function getAnyWorkoutDuration(w: AnyWorkoutTemplate): number {
+  if (isStrengthWorkout(w)) return getStrengthDuration(w);
+  return getWorkoutDuration(w);
+}
+
+/** Zones touched by a workout. Strength sessions have no aerobic zones. */
+function getAnyWorkoutZones(w: AnyWorkoutTemplate): ZoneNumber[] {
+  if (isStrengthWorkout(w)) return [];
+  return getWorkoutZones(w);
+}
+
+function getAnyWorkoutTss(w: AnyWorkoutTemplate): number | null {
+  if (isStrengthWorkout(w)) return null;
+  return estimateTSS(w);
+}
+
+/** "VMA-001" → "001", "LR-014" → "014". */
+function getWorkoutNumber(id: string): string {
+  const parts = id.split("-");
+  return parts[parts.length - 1] || id;
+}
+
+/** Pick a uniformly random element. */
+function sample<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Filter state
+// ────────────────────────────────────────────────────────────────────────────
+
+interface DrawFilters {
+  disciplines: DrawDiscipline[];
+  zones: ZoneNumber[];
+  maxDuration: number;
+  levels: Difficulty[];
+}
+
+const defaultFilters: DrawFilters = {
+  disciplines: [],
+  zones: [],
+  maxDuration: DURATION_MAX,
+  levels: [],
+};
+
+function isFilterActive(f: DrawFilters): boolean {
+  return (
+    f.disciplines.length > 0 ||
+    f.zones.length > 0 ||
+    f.levels.length > 0 ||
+    f.maxDuration !== DURATION_MAX
+  );
+}
+
+function matchesFilters(w: AnyWorkoutTemplate, f: DrawFilters): boolean {
+  // Discipline (multi-select)
+  if (f.disciplines.length > 0 && !f.disciplines.includes(getDrawDiscipline(w))) {
+    return false;
+  }
+  // Duration ceiling
+  if (getAnyWorkoutDuration(w) > f.maxDuration) {
+    return false;
+  }
+  // Level (multi-select)
+  if (f.levels.length > 0 && !f.levels.includes(w.difficulty)) {
+    return false;
+  }
+  // Zones (multi-select). Strength has no zones → excluded once a zone is picked.
+  if (f.zones.length > 0) {
+    const zones = getAnyWorkoutZones(w);
+    if (!zones.some((z) => f.zones.includes(z))) return false;
+  }
+  return true;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Page
+// ────────────────────────────────────────────────────────────────────────────
+
+export function DrawSessionPage() {
+  usePageHint("draw", "hints.draw.title", "hints.draw.description");
+  const { t, i18n } = useTranslation(["library", "common"]);
+  const { t: tStrength } = useTranslation("strength");
+  const pick = usePickLang();
+  const isEn = i18n.language?.startsWith("en") ?? false;
+
+  const { workouts: running } = useWorkouts();
+  const { workouts: strength } = useStrengthWorkouts();
+  const { workouts: cycling } = useCrossDisciplineWorkouts("cycling");
+  const { workouts: swimming } = useCrossDisciplineWorkouts("swimming");
+
+  const catalog: AnyWorkoutTemplate[] = useMemo(
+    () => [...running, ...cycling, ...swimming, ...strength],
+    [running, cycling, swimming, strength],
+  );
+
+  const [filters, setFilters] = useState<DrawFilters>(defaultFilters);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [avoidRepeats, setAvoidRepeats] = useState(true);
+
+  // ── Draw state ───────────────────────────────────────────────────────────
+  const [result, setResult] = useState<AnyWorkoutTemplate | null>(null);
+  const [scanWorkout, setScanWorkout] = useState<AnyWorkoutTemplate | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [history, setHistory] = useState<AnyWorkoutTemplate[]>([]);
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const filtered = useMemo(
+    () => catalog.filter((w) => matchesFilters(w, filters)),
+    [catalog, filters],
+  );
+
+  const filtersActive = isFilterActive(filters);
+  const hasMatches = filtered.length > 0;
+  const proportion = catalog.length > 0 ? filtered.length / catalog.length : 0;
+
+  const clearTimeouts = useCallback(() => {
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+  }, []);
+
+  useEffect(() => clearTimeouts, [clearTimeouts]);
+
+  /** Pick a final result, optionally avoiding the recent history. */
+  const pickFinal = useCallback(
+    (pool: AnyWorkoutTemplate[]): AnyWorkoutTemplate => {
+      if (!avoidRepeats || pool.length <= history.length) {
+        return sample(pool);
+      }
+      const recentIds = new Set(history.map((w) => w.id));
+      const fresh = pool.filter((w) => !recentIds.has(w.id));
+      return sample(fresh.length > 0 ? fresh : pool);
+    },
+    [avoidRepeats, history],
+  );
+
+  /**
+   * Run the "archive drawer" scan: flash through random candidate cards while
+   * decelerating (ease-out) over ~1.5s, then settle on the final pick.
+   */
+  const runDraw = useCallback(
+    (pool: AnyWorkoutTemplate[]) => {
+      if (pool.length === 0 || isDrawing) return;
+      clearTimeouts();
+
+      const final = pickFinal(pool);
+      setIsDrawing(true);
+      setResult(null);
+
+      // Build a schedule whose gaps grow geometrically → ease-out feel.
+      const total = 1500;
+      const times: number[] = [];
+      let elapsed = 0;
+      let gap = 45;
+      while (elapsed < total) {
+        times.push(elapsed);
+        elapsed += gap;
+        gap *= 1.14;
+      }
+
+      times.forEach((at, i) => {
+        const isLast = i === times.length - 1;
+        timeoutsRef.current.push(
+          setTimeout(() => {
+            if (isLast) {
+              setScanWorkout(null);
+              setResult(final);
+              setIsDrawing(false);
+              setHistory((prev) =>
+                [final, ...prev.filter((w) => w.id !== final.id)].slice(
+                  0,
+                  HISTORY_LIMIT,
+                ),
+              );
+            } else {
+              setScanWorkout(sample(pool));
+            }
+          }, at),
+        );
+      });
+    },
+    [isDrawing, clearTimeouts, pickFinal],
+  );
+
+  const handleDraw = useCallback(() => runDraw(filtered), [runDraw, filtered]);
+  const handleSurprise = useCallback(() => runDraw(catalog), [runDraw, catalog]);
+
+  // Space bar shortcut for drawing (ignored while typing in a control).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      const el = e.target as HTMLElement | null;
+      const tag = el?.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "BUTTON" ||
+        el?.isContentEditable
+      ) {
+        return;
+      }
+      if (!hasMatches || isDrawing) return;
+      e.preventDefault();
+      handleDraw();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [handleDraw, hasMatches, isDrawing]);
+
+  // ── Filter mutators ────────────────────────────────────────────────────────
+  const toggleDiscipline = (d: DrawDiscipline) =>
+    setFilters((f) => ({
+      ...f,
+      disciplines: f.disciplines.includes(d)
+        ? f.disciplines.filter((x) => x !== d)
+        : [...f.disciplines, d],
+    }));
+
+  const toggleZone = (z: ZoneNumber) =>
+    setFilters((f) => ({
+      ...f,
+      zones: f.zones.includes(z)
+        ? f.zones.filter((x) => x !== z)
+        : [...f.zones, z],
+    }));
+
+  const toggleLevel = (l: Difficulty) =>
+    setFilters((f) => ({
+      ...f,
+      levels: f.levels.includes(l)
+        ? f.levels.filter((x) => x !== l)
+        : [...f.levels, l],
+    }));
+
+  const resetFilters = () => setFilters(defaultFilters);
+
+  const seoDescription = isEn
+    ? "Let chance pick your next training session. Filter by discipline, zone, duration and level, then draw from the catalogue."
+    : "Laisse le hasard choisir ta prochaine séance. Filtre par discipline, zone, durée et niveau, puis tire dans le catalogue.";
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <>
+      <SEOHead
+        title={t("common:seo.drawTitle")}
+        description={seoDescription}
+        canonical="/library/draw"
+      />
+      <div className="py-8 max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-6">
+          <EditorialTitle as="h1" size="md">
+            {t("draw.title")}
+          </EditorialTitle>
+          <FadeUp as="p" delay={0.1} className="text-muted-foreground mt-1">
+            {t("draw.subtitle")}
+          </FadeUp>
+        </div>
+
+        {/* Mobile filters toggle */}
+        <div className="lg:hidden mb-4">
+          <Button
+            variant="outline"
+            onClick={() => setMobileFiltersOpen((v) => !v)}
+            className="w-full justify-between"
+          >
+            <span className="flex items-center gap-2">
+              <Filter className="size-4" />
+              {t("draw.filters.title")}
+            </span>
+            <span className="text-muted-foreground text-sm">
+              {t("draw.counter.short", { count: filtered.length })}
+            </span>
+          </Button>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+          {/* ── Filters panel ─────────────────────────────────────────────── */}
+          <aside
+            className={cn(
+              "lg:block",
+              mobileFiltersOpen ? "block" : "hidden",
+            )}
+          >
+            <div className="lg:sticky lg:top-20 space-y-6">
+              {/* Live counter */}
+              <Card className="p-4">
+                <div className="flex items-baseline justify-between gap-2">
+                  <div>
+                    <p
+                      className="text-4xl font-bold tabular-nums leading-none"
+                      aria-live="polite"
+                    >
+                      {filtered.length}
+                    </p>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {t("draw.counter.match", { count: filtered.length })}
+                    </p>
+                  </div>
+                  {filtersActive && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={resetFilters}
+                      className="shrink-0"
+                    >
+                      <RotateCcw className="size-3.5 mr-1" />
+                      {t("draw.filters.reset")}
+                    </Button>
+                  )}
+                </div>
+                {/* Proportion bar */}
+                <div
+                  className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted"
+                  role="presentation"
+                >
+                  <div
+                    className="h-full rounded-full bg-primary transition-[width] duration-300"
+                    style={{ width: `${Math.max(proportion * 100, filtered.length > 0 ? 4 : 0)}%` }}
+                  />
+                </div>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  {t("draw.counter.ofTotal", { total: catalog.length })}
+                </p>
+              </Card>
+
+              {/* Discipline */}
+              <FilterGroup label={t("draw.filters.discipline")}>
+                <div className="flex flex-wrap gap-2">
+                  {DISCIPLINES.map((d) => {
+                    const Icon = DISCIPLINE_ICONS[d];
+                    const selected = filters.disciplines.includes(d);
+                    return (
+                      <button
+                        key={d}
+                        type="button"
+                        onClick={() => toggleDiscipline(d)}
+                        aria-pressed={selected}
+                        className={cn(
+                          "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                          selected
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
+                        )}
+                      >
+                        <Icon className="size-3.5" />
+                        {t(`activityToggle.${d === "strength" ? "strength" : d}`)}
+                      </button>
+                    );
+                  })}
+                </div>
+              </FilterGroup>
+
+              {/* Zones */}
+              <FilterGroup label={t("draw.filters.zone")}>
+                <div className="flex flex-wrap gap-1.5">
+                  {ZONE_NUMBERS.map((z) => {
+                    const selected = filters.zones.includes(z);
+                    return (
+                      <button
+                        key={z}
+                        type="button"
+                        onClick={() => toggleZone(z)}
+                        aria-pressed={selected}
+                        className={cn(
+                          `zone-${z}`,
+                          "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold transition-all",
+                          selected
+                            ? "ring-2 ring-offset-1 ring-offset-background"
+                            : "opacity-60 hover:opacity-100",
+                        )}
+                        style={{
+                          backgroundColor: `color-mix(in srgb, var(--zone-${z}) 18%, transparent)`,
+                          borderColor: `var(--zone-${z})`,
+                          color: `var(--zone-${z})`,
+                          // @ts-expect-error CSS custom prop for ring color
+                          "--tw-ring-color": `var(--zone-${z})`,
+                        }}
+                      >
+                        {t(`draw.zoneChips.${z}`)}
+                      </button>
+                    );
+                  })}
+                </div>
+              </FilterGroup>
+
+              {/* Max duration */}
+              <FilterGroup label={t("draw.filters.maxDuration")}>
+                <Slider
+                  value={[filters.maxDuration]}
+                  min={DURATION_MIN}
+                  max={DURATION_MAX}
+                  step={5}
+                  onValueChange={([v]) =>
+                    setFilters((f) => ({ ...f, maxDuration: v }))
+                  }
+                  aria-label={t("draw.filters.maxDuration")}
+                />
+                <div className="mt-1.5 flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{DURATION_MIN} min</span>
+                  <span className="font-semibold text-foreground">
+                    ≤ {filters.maxDuration} min
+                  </span>
+                  <span>{DURATION_MAX} min</span>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {DURATION_PRESETS.map((p) => (
+                    <button
+                      key={p}
+                      type="button"
+                      onClick={() =>
+                        setFilters((f) => ({ ...f, maxDuration: p }))
+                      }
+                      aria-pressed={filters.maxDuration === p}
+                      className={cn(
+                        "rounded-md border px-2 py-1 text-xs font-medium transition-colors",
+                        filters.maxDuration === p
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
+                      )}
+                    >
+                      ≤{p}
+                    </button>
+                  ))}
+                </div>
+              </FilterGroup>
+
+              {/* Level */}
+              <FilterGroup label={t("draw.filters.level")}>
+                <div className="flex flex-col gap-1.5">
+                  {LEVELS.map((l) => {
+                    const selected = filters.levels.includes(l);
+                    const stars = DIFFICULTY_META[l].level;
+                    return (
+                      <button
+                        key={l}
+                        type="button"
+                        onClick={() => toggleLevel(l)}
+                        aria-pressed={selected}
+                        className={cn(
+                          "flex items-center justify-between rounded-md border px-3 py-2 text-sm font-medium transition-colors",
+                          selected
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
+                        )}
+                      >
+                        <span>{t(`difficulty.${l}`)}</span>
+                        <span className="flex items-center gap-0.5">
+                          {Array.from({ length: 4 }).map((_, i) => (
+                            <Star
+                              key={i}
+                              className={cn(
+                                "size-3",
+                                i < stars
+                                  ? "fill-current"
+                                  : "opacity-25",
+                              )}
+                            />
+                          ))}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </FilterGroup>
+            </div>
+          </aside>
+
+          {/* ── Draw zone ─────────────────────────────────────────────────── */}
+          <section className="min-w-0">
+            <div className="rounded-2xl border border-border bg-gradient-to-b from-muted/40 to-transparent p-4 sm:p-6">
+              {/* Draw controls */}
+              <div className="flex flex-col items-center gap-2">
+                <Button
+                  size="lg"
+                  onClick={handleDraw}
+                  disabled={!hasMatches || isDrawing}
+                  className="h-14 px-8 text-base w-full sm:w-auto"
+                >
+                  <Dices className={cn("size-5", isDrawing && "animate-spin")} />
+                  {isDrawing ? t("draw.scanning") : t("draw.draw")}
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  {t("draw.spaceHint")}
+                </p>
+                {filtersActive && (
+                  <button
+                    type="button"
+                    onClick={handleSurprise}
+                    disabled={isDrawing}
+                    className="mt-1 inline-flex items-center gap-1.5 rounded-full border border-dashed border-border px-4 py-1.5 text-sm text-muted-foreground hover:border-primary hover:text-primary transition-colors disabled:opacity-50"
+                  >
+                    <Sparkles className="size-3.5" />
+                    {t("draw.surprise")}
+                  </button>
+                )}
+              </div>
+
+              {/* Result / scan / placeholder / empty */}
+              <div className="mt-6">
+                {!hasMatches ? (
+                  <EmptyState onReset={resetFilters} t={t} />
+                ) : isDrawing && scanWorkout ? (
+                  <ScanCard workout={scanWorkout} pick={pick} />
+                ) : result ? (
+                  <ResultCard
+                    workout={result}
+                    pick={pick}
+                    t={t}
+                    tStrength={tStrength}
+                    onRedraw={handleDraw}
+                    isDrawing={isDrawing}
+                  />
+                ) : (
+                  <Placeholder t={t} />
+                )}
+              </div>
+            </div>
+
+            {/* Recent draws */}
+            {history.length > 0 && (
+              <div className="mt-6">
+                <div className="flex items-center justify-between mb-3">
+                  <h2 className="text-sm font-semibold flex items-center gap-1.5">
+                    <RotateCcw className="size-4 text-muted-foreground" />
+                    {t("draw.recent.title")}
+                  </h2>
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+                    {t("draw.recent.avoidRepeats")}
+                    <Switch
+                      checked={avoidRepeats}
+                      onCheckedChange={setAvoidRepeats}
+                      aria-label={t("draw.recent.avoidRepeats")}
+                    />
+                  </label>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {history.map((w) => {
+                    const zone = isRunningWorkout(w) ? getDominantZone(w) : null;
+                    return (
+                      <button
+                        key={w.id}
+                        type="button"
+                        onClick={() => {
+                          clearTimeouts();
+                          setIsDrawing(false);
+                          setScanWorkout(null);
+                          setResult(w);
+                        }}
+                        className={cn(
+                          "inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors hover:bg-accent",
+                          zone ? `zone-${zone}` : "",
+                          result?.id === w.id
+                            ? "border-primary bg-primary/5"
+                            : "border-border",
+                        )}
+                      >
+                        {zone && (
+                          <span
+                            className="size-2 rounded-full"
+                            style={{ backgroundColor: `var(--zone-${zone})` }}
+                            aria-hidden="true"
+                          />
+                        )}
+                        <span className="max-w-[14rem] truncate">
+                          {pick(w, "name")}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ────────────────────────────────────────────────────────────────────────────
+
+function FilterGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2.5">
+      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function Placeholder({ t }: { t: (k: string) => string }) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-14 text-center">
+      <Dices className="size-10 text-muted-foreground/50 mb-3" />
+      <h3 className="text-base font-medium text-foreground">
+        {t("draw.placeholder.title")}
+      </h3>
+      <p className="mt-1 max-w-xs text-sm text-muted-foreground">
+        {t("draw.placeholder.description")}
+      </p>
+    </div>
+  );
+}
+
+function EmptyState({
+  onReset,
+  t,
+}: {
+  onReset: () => void;
+  t: (k: string) => string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-14 text-center">
+      <X className="size-10 text-muted-foreground/50 mb-3" />
+      <h3 className="text-base font-medium text-foreground">
+        {t("draw.empty.title")}
+      </h3>
+      <p className="mt-1 max-w-xs text-sm text-muted-foreground">
+        {t("draw.empty.description")}
+      </p>
+      <Button variant="outline" size="sm" onClick={onReset} className="mt-4">
+        <RotateCcw className="size-4 mr-1" />
+        {t("draw.empty.reset")}
+      </Button>
+    </div>
+  );
+}
+
+/** Flashing card shown while the catalogue is being scanned. */
+function ScanCard({
+  workout,
+  pick,
+}: {
+  workout: AnyWorkoutTemplate;
+  pick: ReturnType<typeof usePickLang>;
+}) {
+  const zone = isRunningWorkout(workout) ? getDominantZone(workout) : 2;
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl border border-border p-5",
+        `zone-${zone} bg-gradient-to-br from-zone-${zone}/10 to-transparent`,
+      )}
+      aria-hidden="true"
+    >
+      {/* Accent scan line sweeping across the card */}
+      <div
+        className="pointer-events-none absolute inset-y-0 left-0 w-1/3"
+        style={{
+          background:
+            "linear-gradient(90deg, transparent, color-mix(in srgb, var(--primary) 35%, transparent), transparent)",
+          animation: "draw-scan 0.6s linear infinite",
+        }}
+      />
+      <style>{`@keyframes draw-scan { 0% { transform: translateX(-100%);} 100% { transform: translateX(400%);} }`}</style>
+      <p className="text-lg font-semibold opacity-80 line-clamp-1">
+        {pick(workout, "name")}
+      </p>
+      <p className="mt-2 text-sm text-muted-foreground line-clamp-2 opacity-70">
+        {pick(workout, "description")}
+      </p>
+    </div>
+  );
+}
+
+/** Full result card with profile, zones, metrics and actions. */
+function ResultCard({
+  workout,
+  pick,
+  t,
+  tStrength,
+  onRedraw,
+  isDrawing,
+}: {
+  workout: AnyWorkoutTemplate;
+  pick: ReturnType<typeof usePickLang>;
+  t: (k: string, o?: Record<string, unknown>) => string;
+  tStrength: (k: string) => string;
+  onRedraw: () => void;
+  isDrawing: boolean;
+}) {
+  const isStrength = isStrengthWorkout(workout);
+  const discipline = getDrawDiscipline(workout);
+  const DisciplineIcon = DISCIPLINE_ICONS[discipline];
+  const dominantZone = isRunningWorkout(workout)
+    ? getDominantZone(workout)
+    : 2;
+  const zones = getAnyWorkoutZones(workout);
+  const duration = getAnyWorkoutDuration(workout);
+  const tss = getAnyWorkoutTss(workout);
+
+  const methodLabel = isStrength
+    ? tStrength(`categories.${workout.category}`)
+    : t(`categories.${workout.category}`);
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border p-5 motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300",
+        `zone-${dominantZone} bg-gradient-to-br from-zone-${dominantZone}/15 to-transparent`,
+      )}
+    >
+      {/* Eyebrow: discipline · method · n° */}
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <DisciplineIcon className="size-3.5" />
+        <span>{t(`activityToggle.${discipline}`)}</span>
+        <span aria-hidden="true">·</span>
+        <span>{methodLabel}</span>
+        <span aria-hidden="true">·</span>
+        <span className="tabular-nums">n°{getWorkoutNumber(workout.id)}</span>
+      </div>
+
+      {/* Title */}
+      <h3 className="mt-1.5 text-xl font-bold leading-snug">
+        {pick(workout, "name")}
+      </h3>
+      <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+        {pick(workout, "description")}
+      </p>
+
+      {/* Effort profile (aerobic sports only) */}
+      {!isStrength && (
+        <div className="mt-4">
+          <SessionIntensityBar workout={workout} className="h-1.5" />
+        </div>
+      )}
+
+      {/* Zone chips */}
+      {zones.length > 0 && (
+        <div className="mt-3">
+          <ZoneBadges zones={zones} size="sm" />
+        </div>
+      )}
+
+      {/* 4 metrics */}
+      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric
+          icon={Clock}
+          label={t("draw.metrics.duration")}
+          value={formatDurationMinutes(duration)}
+        />
+        <Metric
+          icon={Gauge}
+          label={t("draw.metrics.tss")}
+          value={tss != null ? String(tss) : "—"}
+        />
+        <Metric
+          icon={Target}
+          label={t("draw.metrics.zone")}
+          value={zones.length > 0 ? `Z${dominantZone}` : "—"}
+        />
+        <Metric
+          icon={Star}
+          label={t("draw.metrics.level")}
+          value={t(`difficulty.${workout.difficulty}`)}
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <Button asChild className="flex-1 sm:flex-none">
+          <Link to={`/workout/${workout.id}`}>
+            {t("draw.start")}
+            <ArrowRight className="size-4" />
+          </Link>
+        </Button>
+        <Button asChild variant="outline" className="flex-1 sm:flex-none">
+          <Link to={`/workout/${workout.id}`}>{t("draw.viewDetail")}</Link>
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={onRedraw}
+          disabled={isDrawing}
+          className="flex-1 sm:flex-none"
+        >
+          <RotateCcw className="size-4" />
+          {t("draw.redraw")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-background/60 px-3 py-2">
+      <div className="flex items-center gap-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <p className="mt-0.5 text-sm font-semibold tabular-nums line-clamp-1">
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/src/pages/DrawSessionPage.tsx
+++ b/src/pages/DrawSessionPage.tsx
@@ -137,6 +137,38 @@ const defaultFilters: DrawFilters = {
   levels: [],
 };
 
+// ── Session persistence ──────────────────────────────────────────────────────
+// Keep the drawn session (with filters and history) alive across navigation:
+// opening a workout and hitting "back" should restore the draw, not wipe it.
+// Stored in sessionStorage so it lives for the tab and clears on close.
+const STORAGE_KEY = "zoned-draw-state";
+
+interface DrawSnapshot {
+  result: AnyWorkoutTemplate | null;
+  history: AnyWorkoutTemplate[];
+  filters: DrawFilters;
+  avoidRepeats: boolean;
+}
+
+function readDrawSnapshot(): Partial<DrawSnapshot> {
+  if (typeof sessionStorage === "undefined") return {};
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Partial<DrawSnapshot>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeDrawSnapshot(snap: DrawSnapshot): void {
+  if (typeof sessionStorage === "undefined") return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
+  } catch {
+    /* storage unavailable or full (non-critical) */
+  }
+}
+
 function isFilterActive(f: DrawFilters): boolean {
   return (
     f.disciplines.length > 0 ||
@@ -189,15 +221,26 @@ export function DrawSessionPage() {
     [running, cycling, swimming, strength],
   );
 
-  const [filters, setFilters] = useState<DrawFilters>(defaultFilters);
+  // Restore any previously drawn session (read once on mount).
+  const restored = useMemo(readDrawSnapshot, []);
+  const [filters, setFilters] = useState<DrawFilters>(() => ({
+    ...defaultFilters,
+    ...restored.filters,
+  }));
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
-  const [avoidRepeats, setAvoidRepeats] = useState(true);
+  const [avoidRepeats, setAvoidRepeats] = useState<boolean>(
+    restored.avoidRepeats ?? true,
+  );
 
   // ── Draw state ───────────────────────────────────────────────────────────
-  const [result, setResult] = useState<AnyWorkoutTemplate | null>(null);
+  const [result, setResult] = useState<AnyWorkoutTemplate | null>(
+    restored.result ?? null,
+  );
   const [scanWorkout, setScanWorkout] = useState<AnyWorkoutTemplate | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
-  const [history, setHistory] = useState<AnyWorkoutTemplate[]>([]);
+  const [history, setHistory] = useState<AnyWorkoutTemplate[]>(
+    restored.history ?? [],
+  );
   const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const filtered = useMemo(
@@ -215,6 +258,11 @@ export function DrawSessionPage() {
   }, []);
 
   useEffect(() => clearTimeouts, [clearTimeouts]);
+
+  // Persist the draw so navigating to a workout and back restores it.
+  useEffect(() => {
+    writeDrawSnapshot({ result, history, filters, avoidRepeats });
+  }, [result, history, filters, avoidRepeats]);
 
   /** Pick a final result, optionally avoiding the recent history. */
   const pickFinal = useCallback(

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -61,7 +61,7 @@ import { normalizeSearch } from "@/lib/search-utils";
 
 // Duration constants (same as in WorkoutFilters)
 const DURATION_MIN = 0;
-const DURATION_MAX = 240;
+const DURATION_MAX = 300;
 
 /**
  * Get average duration for a strength workout
@@ -389,9 +389,15 @@ export function LibraryPage() {
         return false;
       }
 
-      // Duration filter
+      // Duration filter. When the upper bound sits at the slider ceiling we
+      // treat it as "no cap", so long sessions above the ceiling (e.g. a
+      // 300-min long run) aren't silently filtered out by default.
       const duration = getAnyWorkoutDuration(workout);
-      if (duration < f.durationRange[0] || duration > f.durationRange[1]) {
+      const capped = f.durationRange[1] < DURATION_MAX;
+      if (
+        duration < f.durationRange[0] ||
+        (capped && duration > f.durationRange[1])
+      ) {
         return false;
       }
 
@@ -755,8 +761,8 @@ export function LibraryPage() {
                 <div className="border-t p-4 flex flex-col gap-2 shrink-0">
                   {(tempFilters.category.length > 0 ||
                     tempFilters.difficulty.length > 0 ||
-                    tempFilters.durationRange[0] !== 0 ||
-                    tempFilters.durationRange[1] !== 240 ||
+                    tempFilters.durationRange[0] !== DURATION_MIN ||
+                    tempFilters.durationRange[1] !== DURATION_MAX ||
                     tempFilters.terrain.length > 0 ||
                     tempFilters.targetSystem.length > 0 ||
                     tempFilters.favoritesOnly ||

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,6 @@
 export { HomePage } from "./HomePage";
 export { LibraryPage } from "./LibraryPage";
+export { DrawSessionPage } from "./DrawSessionPage";
 export { WorkoutDetailPage } from "./WorkoutDetailPage";
 export { MyZonesPage } from "./MyZonesPage";
 export { FavoritesPage } from "./FavoritesPage";


### PR DESCRIPTION
Add a randomised session picker that draws from the full catalogue
(running, cycling, swimming, strength) with an archive-drawer scan
animation.

- Left filter panel (all multi-select): discipline, target zone (Z1→Z6
  coloured chips, Z5 labelled VO₂max / VMA), max-duration slider with
  ≤30/45/60/90/150 presets, and level (Beginner→Elite stars).
- Live counter with a proportion bar and a reset action.
- Draw zone: large "Tirer une séance" button (also bound to Space),
  ~1.5s ease-out scan with an accent scan line, then a full result card
  (discipline · method · n°, title, effort profile, zone badges and the
  Durée / TSS / Zone / Niveau metrics) with Launch / Detail / Re-draw.
- "Surprends-moi" dashed button (ignores filters) shown when filters are
  active; empty state disables the draw and offers a reset.
- Recent draws history (last 5, clickable) with an "avoid repeats" toggle.
- Wired the route /library/draw and added the nav entry under Library
  for both the desktop dropdown and the mobile sheet; FR/EN strings added.