### PR TITLE
Add Strava share text export for workout descriptions

### DIFF
--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -883,6 +883,25 @@ export function Share({ className, size = 24 }: IconProps) {
   );
 }
 
+/**
+ * Strava brand mark. Unlike the stroke-based icons above this logo is
+ * fill-based, so it sets its own SVG attributes instead of `defaultProps`.
+ */
+export function StravaIcon({ className, size = 24 }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      className={className}
+    >
+      <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169" />
+    </svg>
+  );
+}
+
 export function Eye({ className, size = 24 }: IconProps) {
   return (
     <svg {...defaultProps} width={size} height={size} className={className}>

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -113,7 +113,11 @@
     "mistakes": "Common Mistakes"
   },
   "actions": {
-    "findRoute": "Find a matching route"
+    "findRoute": "Find a matching route",
+    "shareStrava": "Share on Strava"
+  },
+  "strava": {
+    "copied": "Workout copied, just paste it on Strava!"
   },
   "variations": {
     "title": "Variations",

--- a/src/i18n/locales/fr/session.json
+++ b/src/i18n/locales/fr/session.json
@@ -113,7 +113,11 @@
     "mistakes": "Erreurs courantes"
   },
   "actions": {
-    "findRoute": "Trouver un parcours adapté"
+    "findRoute": "Trouver un parcours adapté",
+    "shareStrava": "Partager sur Strava"
+  },
+  "strava": {
+    "copied": "Séance copiée, il ne reste plus qu'à la coller sur Strava !"
   },
   "variations": {
     "title": "Variantes",

--- a/src/lib/export/ics.ts
+++ b/src/lib/export/ics.ts
@@ -11,9 +11,13 @@ import i18n from "@/i18n";
 import { isEnglish, pickLang } from "@/lib/i18n-utils";
 
 /**
- * Formats workout blocks into a readable description for calendar events
+ * Formats workout blocks into a readable, multi-line description.
+ *
+ * Reused by both the ICS calendar export and the Strava share-text builder
+ * so the human-readable breakdown (description → warmup/main/cooldown →
+ * tips) stays consistent across surfaces.
  */
-function formatWorkoutDescription(workout: WorkoutTemplate): string {
+export function formatWorkoutDescription(workout: WorkoutTemplate): string {
   const lines: string[] = [];
   const t = (key: string) => i18n.t(`common:export.ics.${key}`);
 

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -28,3 +28,6 @@ export {
   type ShareMethod,
 } from "./share";
 export { getWorkoutHero, type WorkoutHero } from "./workoutHero";
+
+// Strava share text (copy-to-clipboard for activity descriptions).
+export { buildStravaShareText } from "./strava";

--- a/src/lib/export/strava.ts
+++ b/src/lib/export/strava.ts
@@ -1,0 +1,34 @@
+/**
+ * Strava share-text builder.
+ *
+ * Produces a plain-text block (title + workout breakdown + canonical link)
+ * the user copies to their clipboard and pastes into the description of a
+ * Strava activity. No GPS/GPX is included: Strava can't accept a track
+ * pasted as text, so that stays out of scope for this MVP.
+ */
+
+import type { WorkoutTemplate } from "@/types";
+import { pickLang } from "@/lib/i18n-utils";
+import { formatWorkoutDescription } from "./ics";
+
+/** Canonical public URL for a workout (mirrors `workoutShareUrl`). */
+function workoutUrl(workoutId: string): string {
+  const origin =
+    typeof window !== "undefined" && window.location.origin
+      ? window.location.origin
+      : "https://zoned.run";
+  return `${origin}/workout/${workoutId}`;
+}
+
+/**
+ * Build the Strava share text for a running workout: title, then the shared
+ * description breakdown, then a `via <url>` footer linking back to the
+ * session. Language follows the active i18n locale via `pickLang()`.
+ */
+export function buildStravaShareText(workout: WorkoutTemplate): string {
+  const title = pickLang(workout, "name");
+  const body = formatWorkoutDescription(workout);
+  const footer = `via ${workoutUrl(workout.id)}`;
+
+  return `${title}\n\n${body}\n\n${footer}`;
+}

--- a/src/pages/WorkoutDetailPage.tsx
+++ b/src/pages/WorkoutDetailPage.tsx
@@ -23,6 +23,7 @@ import {
   BookOpen,
   Sparkles,
   Share,
+  StravaIcon,
 } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -39,6 +40,7 @@ import { ExportMenu } from "@/components/domain/ExportMenu";
 import { ShareDialog } from "@/components/share/ShareDialog";
 import { toast } from "sonner";
 import { copyToClipboard } from "@/lib/issueBuilder";
+import { buildStravaShareText } from "@/lib/export";
 import { NutritionRecoverySection } from "@/components/domain/NutritionRecoverySection";
 import { ScienceSection } from "@/components/domain/ScienceSection";
 import { GlossaryLinkedText } from "@/components/domain/GlossaryLinkedText";
@@ -470,6 +472,19 @@ export function WorkoutDetailPage() {
             >
               <Share className="size-3.5 mr-1.5" />
               {t("common:share.trigger")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="rounded-full px-4"
+              onClick={async () => {
+                const ok = await copyToClipboard(buildStravaShareText(workout));
+                if (ok) toast.success(t("session:strava.copied"));
+                else toast.error(t("common:errors.generic"));
+              }}
+            >
+              <StravaIcon className="size-3.5 mr-1.5 text-[#FC4C02]" />
+              {t("session:actions.shareStrava")}
             </Button>
             {canGenerateRoute && (
               <Button asChild variant="outline" size="sm" className="rounded-full px-4">


### PR DESCRIPTION
## Description

Adds the ability to share workout descriptions directly to Strava by generating a formatted text block that users can copy and paste into their activity descriptions. This includes:

- New `buildStravaShareText()` function that formats a workout as shareable text (title + description breakdown + canonical link)
- Refactored `formatWorkoutDescription()` to be reusable across both ICS calendar export and Strava share text
- New "Share on Strava" button on the workout detail page with Strava brand icon
- Bilingual UI strings (EN/FR) for the button and success toast notification

The implementation follows the existing export patterns and reuses the workout description formatting logic to ensure consistency across surfaces.

## Type of change

- [x] Nouvelle fonctionnalité / New feature

## Checklist

- [x] Le build TypeScript passe (`bun run build`)
- [x] Les textes sont bilingues FR/EN si applicable
- [x] La fonctionnalité a été testée visuellement dans l'app

https://claude.ai/code/session_018Sg9w4sHQByNK8qh8bZpGE