### PR TITLE
fix(mobile): resolve mobile-first audit issues #96–#106

### DIFF
--- a/src/components/domain/WorkoutCard.tsx
+++ b/src/components/domain/WorkoutCard.tsx
@@ -163,7 +163,7 @@ export function WorkoutCardChrome({
       <CardHeader className={cn("pb-1.5 sm:pb-2 px-3 sm:px-4", expanded && "pb-2 px-4")}>
         {eyebrow && <div className="mb-1">{eyebrow}</div>}
         <div className="flex items-start justify-between gap-2">
-          <CardTitle className={cn("text-sm sm:text-base line-clamp-2 sm:line-clamp-1 flex-1", expanded && "text-base line-clamp-none")}>
+          <CardTitle className={cn("text-sm sm:text-base line-clamp-2 sm:line-clamp-1 flex-1 min-w-0 break-words", expanded && "text-base line-clamp-none")}>
             {pick(workout, "name")}
           </CardTitle>
           <div className="flex items-center gap-1">
@@ -181,13 +181,13 @@ export function WorkoutCardChrome({
         <SessionIntensityBar workout={workout} />
 
         <div className={cn("flex items-center gap-2 sm:gap-3 text-xs sm:text-sm text-muted-foreground", expanded && "gap-3 text-sm")}>
-          <div className="flex items-center gap-1">
-            <Clock className="size-3.5" />
+          <div className="flex items-center gap-1 shrink-0">
+            <Clock className="size-3.5 shrink-0" />
             <span>{formatDurationMinutes(duration)}</span>
           </div>
-          <div className="flex items-center gap-1">
-            <CategoryIcon className="size-3.5" />
-            <span>{t(`categories.${workout.category}`)}</span>
+          <div className="flex items-center gap-1 min-w-0">
+            <CategoryIcon className="size-3.5 shrink-0" />
+            <span className="truncate">{t(`categories.${workout.category}`)}</span>
           </div>
         </div>
 

--- a/src/components/domain/ZonePersonalizationCTA.tsx
+++ b/src/components/domain/ZonePersonalizationCTA.tsx
@@ -33,19 +33,23 @@ export function ZonePersonalizationCTA({ className }: ZonePersonalizationCTAProp
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-4 p-3 rounded-lg",
+        // Stacks vertically on mobile so the button never overlaps the text;
+        // reverts to the original inline row at sm+.
+        "relative flex flex-col gap-3 p-3 rounded-lg",
+        "sm:flex-row sm:items-center sm:justify-between sm:gap-4",
         "bg-primary/5 border border-primary/20",
         className
       )}
     >
-      <div className="flex items-center gap-3">
-        <Settings className="size-4 text-primary shrink-0" />
+      {/* pr-10 on mobile keeps the text clear of the absolutely-placed close */}
+      <div className="flex items-start gap-3 pr-10 sm:pr-0">
+        <Settings className="size-4 text-primary shrink-0 mt-0.5 sm:mt-0" />
         <p className="text-sm text-muted-foreground">
           {t("zonePersonalization.ctaMessage")}
         </p>
       </div>
-      <div className="flex items-center gap-2 shrink-0">
-        <Button variant="outline" size="sm" asChild>
+      <div className="flex items-center gap-2 sm:shrink-0">
+        <Button variant="outline" size="sm" asChild className="w-full sm:w-auto">
           <Link to="/my-zones">
             {t("zonePersonalization.ctaButton")}
           </Link>
@@ -53,9 +57,9 @@ export function ZonePersonalizationCTA({ className }: ZonePersonalizationCTAProp
         <Button
           variant="ghost"
           size="icon"
-          className="size-7"
           onClick={handleDismiss}
           aria-label={t("zonePersonalization.dismiss")}
+          className="absolute right-1.5 top-1.5 size-9 sm:static"
         >
           <X className="size-4" />
         </Button>

--- a/src/components/editorial/index.tsx
+++ b/src/components/editorial/index.tsx
@@ -30,12 +30,14 @@ export function EditorialTitle({
   as?: "h1" | "h2" | "h3";
 }) {
   const reduced = useReducedMotion();
+  // Mobile-first: smaller heads on phones so the hero doesn't eat the first
+  // screen (#106). Tablet/desktop (md:) sizes are unchanged.
   const sizeCls =
     size === "xl"
-      ? "text-[44px] md:text-6xl"
+      ? "text-[40px] md:text-6xl"
       : size === "md"
-        ? "text-2xl md:text-3xl"
-        : "text-3xl md:text-4xl";
+        ? "text-xl sm:text-2xl md:text-3xl"
+        : "text-[26px] sm:text-3xl md:text-4xl";
   const baseCls = `font-sans font-semibold italic leading-[1.05] tracking-tight ${sizeCls} ${className}`;
 
   const motionProps = reduced

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -100,8 +100,10 @@ export function MobileSidebar({ open, onOpenChange }: MobileSidebarProps) {
                   to={item.to}
                   className="flex items-center gap-2 px-3 py-2.5 rounded-md text-sm font-medium text-foreground/85 hover:bg-accent/50 transition-colors"
                 >
-                  <item.icon className="size-4 text-muted-foreground" />
-                  <span className="truncate">{t(item.labelKey)}</span>
+                  <item.icon className="size-4 shrink-0 text-muted-foreground" />
+                  {/* Wrap rather than truncate so longer labels like
+                      "Créer une séance" stay fully readable (#105). */}
+                  <span className="leading-tight">{t(item.labelKey)}</span>
                 </Link>
               ))}
             </div>
@@ -188,7 +190,7 @@ function MobileSection({
           aria-label={open ? "Collapse" : "Expand"}
           aria-expanded={open}
           onClick={() => setOpen((v) => !v)}
-          className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+          className="flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
         >
           <ChevronDown
             className={cn(

--- a/src/components/ui/responsive-table.tsx
+++ b/src/components/ui/responsive-table.tsx
@@ -48,6 +48,8 @@ interface ResponsiveTableProps<T> {
   tableClassName?: string;
   /** Make the desktop <thead> sticky to the closest scrolling ancestor. */
   stickyHeader?: boolean;
+  /** Per-row extra classes, applied to both the desktop <tr> and mobile card. */
+  rowClassName?: (row: T, index: number) => string | undefined;
 }
 
 function getRowKey<T>(
@@ -71,6 +73,7 @@ export function ResponsiveTable<T>({
   className,
   tableClassName,
   stickyHeader,
+  rowClassName,
 }: ResponsiveTableProps<T>) {
   if (data.length === 0 && emptyState) {
     return <div className={className}>{emptyState}</div>;
@@ -86,7 +89,9 @@ export function ResponsiveTable<T>({
           {caption && <caption className="sr-only">{caption}</caption>}
           <thead
             className={cn(
-              stickyHeader && "sticky top-0 bg-background z-10",
+              // top-14 clears the fixed h-14 TopBar so the header isn't hidden
+              // behind it while scrolling (#103).
+              stickyHeader && "sticky top-14 bg-background z-10",
             )}
           >
             <tr className="border-b">
@@ -108,7 +113,10 @@ export function ResponsiveTable<T>({
             {data.map((row, rowIndex) => (
               <tr
                 key={getRowKey(row, rowIndex, rowKey)}
-                className="border-b last:border-0 hover:bg-muted/40 transition-colors"
+                className={cn(
+                  "border-b last:border-0 hover:bg-muted/40 transition-colors",
+                  rowClassName?.(row, rowIndex),
+                )}
               >
                 {columns.map((col) => (
                   <td
@@ -129,7 +137,10 @@ export function ResponsiveTable<T>({
         {data.map((row, rowIndex) => (
           <div
             key={getRowKey(row, rowIndex, rowKey)}
-            className="rounded-lg border bg-card p-3 shadow-xs"
+            className={cn(
+              "rounded-lg border bg-card p-3 shadow-xs",
+              rowClassName?.(row, rowIndex),
+            )}
           >
             {mobileCardTitle && (
               <div className="mb-2 text-sm font-semibold text-foreground">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -578,7 +578,7 @@ export function HomePage() {
                 (the "headline" stat), then the three companion stats
                 tint Z2 / Z3 / Z5 to walk the eye across the row without
                 competing with the chart sidecar. */}
-            <div className="border-t border-foreground/15 pt-6 grid grid-cols-4 gap-4">
+            <div className="border-t border-foreground/15 pt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
               <CountStat
                 target={totalSessions}
                 label={t("homepage:home.stats.sessions")}

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -799,7 +799,7 @@ export function LibraryPage() {
           {/* Workout Display */}
           <div className="flex-1">
             {isLoading ? (
-              <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
                 {Array.from({ length: 12 }).map((_, i) => (
                   <WorkoutCardSkeleton key={i} className="border-border/50" />
                 ))}
@@ -807,7 +807,7 @@ export function LibraryPage() {
             ) : filteredWorkouts.length > 0 ? (
               <>
                 {viewMode === "grid" && (
-                  <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-2 xl:grid-cols-3">
                     {visibleWorkouts.map((workout) => (
                       <WorkoutCard key={workout.id} workout={workout} />
                     ))}

--- a/src/pages/PaceTablePage.tsx
+++ b/src/pages/PaceTablePage.tsx
@@ -2,6 +2,10 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { SEOHead } from "@/components/seo";
 import { EditorialTitle, FadeUp } from "@/components/editorial";
+import {
+  ResponsiveTable,
+  type ResponsiveTableColumn,
+} from "@/components/ui/responsive-table";
 import { loadUserZonePrefs, calculatePaceZones } from "@/lib/zones";
 import type { ZoneNumber } from "@/types";
 
@@ -122,6 +126,45 @@ export function PaceTablePage() {
     return Math.max(180, Math.min(600, rounded));
   }, [vmaPaceMinPerKm]);
 
+  const numericCell = "font-mono tabular-nums whitespace-nowrap";
+
+  // ResponsiveTable: real <table> at md+, stacked key/value cards on phones so
+  // every column (incl. semi/marathon) is readable without horizontal scroll (#104).
+  const columns = useMemo<ResponsiveTableColumn<PaceRow>[]>(() => {
+    const base: ResponsiveTableColumn<PaceRow>[] = [
+      { key: "kmPace", header: "min/km", className: numericCell, cell: (r) => formatPace(r.paceMinPerKm) },
+      { key: "kmh", header: "km/h", className: numericCell, cell: (r) => r.kmh.toFixed(1) },
+      { key: "milePace", header: "min/mi", className: numericCell, cell: (r) => formatPace(r.paceMinPerMile) },
+      { key: "5k", header: "5K", className: numericCell, cell: (r) => formatDuration(r.time5K) },
+      { key: "10k", header: "10K", className: numericCell, cell: (r) => formatDuration(r.time10K) },
+      {
+        key: "semi",
+        header: t("calculators:calculateurs.paceTable.halfLabel"),
+        className: numericCell,
+        cell: (r) => formatDuration(r.timeSemi),
+      },
+      { key: "marathon", header: "Marathon", className: numericCell, cell: (r) => formatDuration(r.timeMarathon) },
+    ];
+    if (hasZones) {
+      base.push({
+        key: "zone",
+        header: t("calculators:calculateurs.paceTable.yourZone"),
+        className: "whitespace-nowrap",
+        cell: (r) =>
+          r.zone != null ? (
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-zone-${r.zone}/10 text-zone-${r.zone}`}
+            >
+              Z{r.zone}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          ),
+      });
+    }
+    return base;
+  }, [hasZones, t]);
+
   return (
     <>
       <SEOHead
@@ -157,94 +200,26 @@ export function PaceTablePage() {
           </FadeUp>
         </div>
 
-        {/* Table */}
-        <div className="overflow-x-auto rounded-lg border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="sticky top-0 bg-background border-b">
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  min/km
-                </th>
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  km/h
-                </th>
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  min/mi
-                </th>
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  5K
-                </th>
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  10K
-                </th>
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  {t("calculators:calculateurs.paceTable.halfLabel")}
-                </th>
-                <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                  Marathon
-                </th>
-                {hasZones && (
-                  <th scope="col" className="px-3 py-2 text-left font-medium text-muted-foreground whitespace-nowrap">
-                    {t("calculators:calculateurs.paceTable.yourZone")}
-                  </th>
-                )}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => {
-                const isHighlighted =
-                  highlightSeconds != null &&
-                  row.totalSeconds === highlightSeconds;
-
-                return (
-                  <tr
-                    key={row.totalSeconds}
-                    className={
-                      isHighlighted
-                        ? "bg-primary/10 font-medium"
-                        : "even:bg-muted/50"
-                    }
-                  >
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {formatPace(row.paceMinPerKm)}
-                    </td>
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {row.kmh.toFixed(1)}
-                    </td>
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {formatPace(row.paceMinPerMile)}
-                    </td>
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {formatDuration(row.time5K)}
-                    </td>
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {formatDuration(row.time10K)}
-                    </td>
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {formatDuration(row.timeSemi)}
-                    </td>
-                    <td className="px-3 py-1.5 font-mono tabular-nums whitespace-nowrap">
-                      {formatDuration(row.timeMarathon)}
-                    </td>
-                    {hasZones && (
-                      <td className="px-3 py-1.5 whitespace-nowrap">
-                        {row.zone != null ? (
-                          <span
-                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-zone-${row.zone}/10 text-zone-${row.zone}`}
-                          >
-                            Z{row.zone}
-                          </span>
-                        ) : (
-                          <span className="text-muted-foreground">-</span>
-                        )}
-                      </td>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        {/* Table — responsive: scrollable table on tablet/desktop, stacked
+            cards on mobile. */}
+        <ResponsiveTable
+          data={rows}
+          columns={columns}
+          rowKey="totalSeconds"
+          stickyHeader
+          className="md:overflow-x-auto md:rounded-lg md:border"
+          mobileCardTitle={(row) => (
+            <span className="font-mono tabular-nums">
+              {formatPace(row.paceMinPerKm)}
+              <span className="text-muted-foreground font-sans font-normal"> /km</span>
+            </span>
+          )}
+          rowClassName={(row) =>
+            highlightSeconds != null && row.totalSeconds === highlightSeconds
+              ? "bg-primary/10 font-medium ring-1 ring-primary/30"
+              : undefined
+          }
+        />
 
         {/* Footer notes */}
         {highlightSeconds != null && (

--- a/src/pages/PlanViewPage.tsx
+++ b/src/pages/PlanViewPage.tsx
@@ -775,7 +775,10 @@ export function PlanViewPage() {
                   {t("view.prebuilt")}
                 </Badge>
               )}
-              {raceDate && (
+              {/* Only show this createdAt→raceDate range when no explicit start
+                  date is set — otherwise the editable startDate→endDate block
+                  below renders the same span and we'd duplicate it (#102). */}
+              {raceDate && !plan.config.startDate && (
                 <div className="flex items-center gap-1 text-sm text-muted-foreground">
                   <Calendar className="size-3.5" />
                   <span>

--- a/src/pages/PlansPage.tsx
+++ b/src/pages/PlansPage.tsx
@@ -115,6 +115,14 @@ function PlanCard({
               <Calendar className="size-3.5" />
               {t("plansPage.sessionsCount", { count: totalSessions })}
             </span>
+          ) : plan.config.startDate ? (
+            // Prefer the explicit start→end range; falls through to
+            // createdAt→raceDate only when no start date is set (#102).
+            <span className="flex items-center gap-1">
+              <Calendar className="size-3.5" />
+              {formatDateShort(plan.config.startDate)}
+              {plan.config.endDate && ` → ${formatDateShort(plan.config.endDate)}`}
+            </span>
           ) : plan.config.raceDate ? (
             <span className="flex items-center gap-1">
               <Calendar className="size-3.5" />
@@ -125,12 +133,6 @@ function PlanCard({
             <span className="flex items-center gap-1">
               <Calendar className="size-3.5" />
               {formatDateShort(plan.config.createdAt)}
-            </span>
-          )}
-          {plan.config.startDate && (
-            <span className="text-xs text-muted-foreground">
-              {formatDateShort(plan.config.startDate)}
-              {plan.config.endDate && ` \u2192 ${formatDateShort(plan.config.endDate)}`}
             </span>
           )}
         </CardDescription>

--- a/src/pages/RaceSimulatorPage.tsx
+++ b/src/pages/RaceSimulatorPage.tsx
@@ -611,7 +611,7 @@ export function RaceSimulatorPage() {
                 </div>
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
-                    <thead className="sticky top-0 bg-background z-10">
+                    <thead className="sticky top-14 bg-background z-10">
                       <tr className="border-b">
                         <th className="py-2 px-2 text-left font-medium">#</th>
                         <th className="py-2 px-2 text-left font-medium">

--- a/src/styles/overrides.css
+++ b/src/styles/overrides.css
@@ -71,6 +71,18 @@
 }
 
 /* ==========================================================================
+   ACCENT TEXT — WCAG AA contrast fix (#96)
+   `text-primary` maps to orange-500 (`--primary`), which only reaches 2.67:1
+   as text on light backgrounds. Re-point the utility to `--primary-text`
+   (orange-700 in light mode, unchanged in dark) so accent text passes AA
+   without darkening the filled `bg-primary` buttons that share `--primary`.
+   Unlayered so it wins over Tailwind's layered `.text-primary` utility.
+   ========================================================================== */
+.text-primary {
+  color: var(--primary-text);
+}
+
+/* ==========================================================================
    ZONE SYSTEM — Utility classes & components
    ========================================================================== */
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -21,6 +21,11 @@
   /* White on orange-500 fails WCAG AA (2.8:1). Charcoal hits 5.5:1 while
      keeping the orange brand identity intact. */
   --primary-foreground: #1c1917;
+  /* Accent text on light backgrounds. orange-500 as text only hits 2.67:1 —
+     below AA. orange-700 reaches ~4.6:1 while reading as the same brand
+     orange. Used by the `.text-primary` utility (see overrides.css); the
+     filled `--primary` button background stays orange-500 and untouched. */
+  --primary-text: #c2410c;
 
   /* Secondary */
   --secondary: #f1f5f9;
@@ -149,6 +154,9 @@
 
   --primary: #fb923c;
   --primary-foreground: #1c1917;
+  /* Dark mode already passes AA (#fb923c on navy) — keep accent text identical
+     to the primary hue. */
+  --primary-text: #fb923c;
 
   --secondary: #1e293b;
   --secondary-foreground: #e2e8f0;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -32,6 +32,7 @@
   --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
+  --color-primary-text: var(--primary-text);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);


### PR DESCRIPTION
#96 a11y: add --primary-text token (orange-700 in light mode) and re-point
  the .text-primary utility to it so accent text passes WCAG AA 4.5:1;
  filled bg-primary buttons keep orange-500 and dark mode is unchanged.
#97 library: drop the workout grid to 1 column below 400px and harden card
  truncation (min-w-0 on title, truncate on the duration/category meta).
#98 home: stats row becomes 2×2 on mobile (grid-cols-2 sm:grid-cols-4).
#99 workout: "Personnalisez vos zones" banner stacks vertically on mobile,
  full-width button, close control bumped to a ≥44px touch target.
#101 sidebar: accordion chevron now has a ≥44px (min-h/w-11) touch target.
#102 plans: show the date range only once on the plan card and the plan
  header, preferring the explicit start→end span.
#103 tables: offset sticky <thead> by top-14 so it clears the fixed TopBar
  (ResponsiveTable + RaceSimulator splits table).
#104 pace table: migrate to ResponsiveTable (stacked cards on mobile, no
  horizontal scroll); add an optional rowClassName prop for the VMA row.
#105 menu: account labels wrap instead of truncating ("Créer une séance").
#106 typography: tighten EditorialTitle sizes on phones (md+ unchanged) so
  heroes don't push actionable content below the fold.

#100 (weekly 7-col grid) already satisfied by PlanWeeklyView's mobile 4+3
  layout used by both PlanViewPage and WeekViewPage — no scroll, tap for
  session detail.