### PR TITLE
feat(cards): add mobile-first interactive motion to card grids

### DIFF
--- a/src/components/domain/ArticleCard.tsx
+++ b/src/components/domain/ArticleCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Clock, BookOpen, Heart, Dumbbell } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
+import { InteractiveCard } from "@/components/editorial";
 import { cn } from "@/lib/utils";
 import type { ArticleMeta, ArticleCategory } from "@/data/articles";
 import { GlossaryLinkedText } from "@/components/domain/GlossaryLinkedText";
@@ -18,6 +19,14 @@ const CATEGORY_GRADIENT: Record<ArticleCategory, string> = {
   lifestyle: "from-green-500/10 dark:from-green-500/20",
 };
 
+// Spotlight tint per category — matches the gradient hue above
+// (blue-500 / orange-500 / green-500).
+const CATEGORY_ACCENT: Record<ArticleCategory, string> = {
+  fundamentals: "#3b82f6",
+  training: "#f97316",
+  lifestyle: "#22c55e",
+};
+
 interface ArticleCardProps {
   article: ArticleMeta;
 }
@@ -27,13 +36,14 @@ export function ArticleCard({ article }: ArticleCardProps) {
   const CategoryIcon = CATEGORY_ICONS[article.category];
 
   return (
-    <Link to={`/learn/${article.slug}`} className="group block h-full">
-      <div
+    <Link to={`/learn/${article.slug}`} className="block h-full">
+      <InteractiveCard
+        accent={CATEGORY_ACCENT[article.category]}
         className={cn(
           "rounded-lg sm:rounded-xl border border-border/50 h-full p-4 sm:p-6",
           "bg-gradient-to-br to-transparent",
           CATEGORY_GRADIENT[article.category],
-          "hover:shadow-sm hover:-translate-y-0.5 hover:border-foreground/40 active:translate-y-0 transition-all duration-200",
+          "hover:shadow-sm hover:border-foreground/40 transition-[box-shadow,border-color] duration-200",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         )}
       >
@@ -56,7 +66,7 @@ export function ArticleCard({ article }: ArticleCardProps) {
             </Badge>
           </div>
         </div>
-      </div>
+      </InteractiveCard>
     </Link>
   );
 }

--- a/src/components/domain/CollectionCard.tsx
+++ b/src/components/domain/CollectionCard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/icons";
 import type { IconProps } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
+import { InteractiveCard } from "@/components/editorial";
 import { cn } from "@/lib/utils";
 import type { Collection } from "@/data/collections/types";
 import { usePickLang } from "@/lib/i18n-utils";
@@ -76,14 +77,15 @@ export function CollectionCard({ collection }: CollectionCardProps) {
   const zone = getCollectionZone(collection.slug);
 
   return (
-    <Link to={`/collections/${collection.slug}`} className="group block h-full">
-      <div
+    <Link to={`/collections/${collection.slug}`} className="block h-full">
+      <InteractiveCard
+        accent={`var(--zone-${zone})`}
         className={cn(
           "rounded-lg sm:rounded-xl border border-border/50 h-full p-4 sm:p-6",
           `zone-${zone}`,
           "bg-gradient-to-br to-transparent",
           ZONE_GRADIENT[zone],
-          "hover:shadow-sm hover:-translate-y-0.5 hover:border-foreground/40 active:translate-y-0 transition-all duration-200",
+          "hover:shadow-sm hover:border-foreground/40 transition-[box-shadow,border-color] duration-200",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         )}
       >
@@ -110,7 +112,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
             </Badge>
           </div>
         </div>
-      </div>
+      </InteractiveCard>
     </Link>
   );
 }

--- a/src/components/domain/PrebuiltPlanCard.tsx
+++ b/src/components/domain/PrebuiltPlanCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { InteractiveCard } from "@/components/editorial";
 import { cn } from "@/lib/utils";
 import { RACE_DISTANCE_META } from "@/types/plan";
 import type { PrebuiltPlan } from "@/data/prebuilt-plans/types";
@@ -13,6 +14,15 @@ const DIFFICULTY_GRADIENT: Record<string, string> = {
   intermediate: "bg-gradient-to-br from-yellow-500/10 dark:from-yellow-500/20 to-transparent",
   advanced: "bg-gradient-to-br from-orange-500/10 dark:from-orange-500/20 to-transparent",
   elite: "bg-gradient-to-br from-red-500/10 dark:from-red-500/20 to-transparent",
+};
+
+// Spotlight tint per difficulty — matches the gradient hue above
+// (green / yellow / orange / red -500).
+const DIFFICULTY_ACCENT: Record<string, string> = {
+  beginner: "#22c55e",
+  intermediate: "#eab308",
+  advanced: "#f97316",
+  elite: "#ef4444",
 };
 
 const DIFFICULTY_KEYS: Record<string, string> = {
@@ -39,8 +49,11 @@ export function PrebuiltPlanCard({ plan }: PrebuiltPlanCardProps) {
 
   return (
     <Link to={`/plan/prebuilt/${plan.slug}`} className="group block h-full">
+      <InteractiveCard
+        accent={DIFFICULTY_ACCENT[plan.difficulty] ?? "var(--primary)"}
+        className="block h-full rounded-xl"
+      >
       <Card
-        interactive
         className={cn(
           "h-full border-border/50",
           DIFFICULTY_GRADIENT[plan.difficulty] ?? "bg-gradient-to-br from-gray-400/10 dark:from-gray-400/20 to-transparent",
@@ -73,6 +86,7 @@ export function PrebuiltPlanCard({ plan }: PrebuiltPlanCardProps) {
           </div>
         </CardContent>
       </Card>
+      </InteractiveCard>
     </Link>
   );
 }

--- a/src/components/domain/WorkoutCard.tsx
+++ b/src/components/domain/WorkoutCard.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/icons";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { InteractiveCard } from "@/components/editorial";
 import { ZoneBadge, ZoneBadges } from "./ZoneBadge";
 import { FavoriteButton } from "./FavoriteButton";
 import { getWorkoutZones } from "@/lib/landing-stats";
@@ -282,9 +283,20 @@ export function WorkoutCardChrome({
 
 /** Internal running-only card with properly typed props */
 function RunningWorkoutCard({ workout, className, expanded }: { workout: WorkoutTemplate; className?: string; expanded?: boolean }) {
+  const dominantZone = getDominantZone(workout);
   return (
-    <Link to={`/workout/${workout.id}`}>
-      <WorkoutCardChrome workout={workout} className={className} expanded={expanded} />
+    <Link to={`/workout/${workout.id}`} className="block h-full">
+      <InteractiveCard
+        accent={`var(--zone-${dominantZone})`}
+        className="block h-full rounded-xl"
+      >
+        <WorkoutCardChrome
+          workout={workout}
+          className={className}
+          expanded={expanded}
+          interactive={false}
+        />
+      </InteractiveCard>
     </Link>
   );
 }
@@ -320,15 +332,16 @@ function RunningWorkoutCardCompact({ workout, className }: { workout: WorkoutTem
       : null;
 
   return (
-    <Link
-      to={`/workout/${workout.id}`}
-      className={cn(
-        `zone-${dominantZone} bg-gradient-to-br from-zone-${dominantZone}/10 dark:from-zone-${dominantZone}/20 to-transparent`,
-        "border-border/50",
-        "block p-3 rounded-xl border hover:bg-accent/50 transition-colors",
-        className
-      )}
-    >
+    <Link to={`/workout/${workout.id}`} className="block h-full">
+      <InteractiveCard
+        accent={`var(--zone-${dominantZone})`}
+        className={cn(
+          `zone-${dominantZone} bg-gradient-to-br from-zone-${dominantZone}/10 dark:from-zone-${dominantZone}/20 to-transparent`,
+          "border-border/50",
+          "block p-3 rounded-xl border h-full",
+          className
+        )}
+      >
       <div className="flex items-center justify-between gap-2">
         <span className="font-medium text-sm line-clamp-1 flex-1">
           {pick(workout, "name")}
@@ -350,6 +363,7 @@ function RunningWorkoutCardCompact({ workout, className }: { workout: WorkoutTem
         </span>
         <FavoriteButton workoutId={workout.id} size="sm" />
       </div>
+      </InteractiveCard>
     </Link>
   );
 }

--- a/src/components/editorial/InteractiveCard.tsx
+++ b/src/components/editorial/InteractiveCard.tsx
@@ -1,0 +1,125 @@
+/**
+ * InteractiveCard — the shared motion shell for every card grid in the app.
+ *
+ * Mobile-first by design (≈95 % of traffic is touch):
+ *  - Tap feedback (`whileTap`) is the *primary* interaction and runs on every
+ *    device, so a tap always feels physical.
+ *  - The cursor-following spotlight glow and the spring lift are *progressive
+ *    enhancement* — they only mount on hover-capable, fine-pointer devices, so
+ *    touch devices never pay for pointer maths they can't use.
+ *  - Under `prefers-reduced-motion` it renders as a plain element with no
+ *    transforms or glow, matching the rest of the editorial atoms.
+ *
+ * Polymorphic: pass `to` for a router link, `href` for an anchor, or neither
+ * for a div. Keep your existing Tailwind on `className` (gradient, border,
+ * `rounded-*`, `focus-visible:*`); just drop the old `hover:-translate-y-*` /
+ * `transition-all` lift — the spring owns that now. The glow is tinted by
+ * `accent` (any CSS colour; zone cards pass `var(--zone-N)`).
+ */
+
+import { Link } from "react-router-dom";
+import {
+  motion,
+  useMotionValue,
+  useMotionTemplate,
+  useReducedMotion,
+} from "framer-motion";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { cn } from "@/lib/utils";
+
+const MotionLink = motion.create(Link);
+
+// Refined, not bouncy — a controlled spring that settles quickly.
+const SPRING = { type: "spring", stiffness: 380, damping: 30 } as const;
+
+interface InteractiveCardProps {
+  /** CSS colour used to tint the cursor-following glow. Defaults to the brand
+   *  primary; zone cards pass `var(--zone-N)`. */
+  accent?: string;
+  /** Opt out of the desktop spotlight glow (lift + tap stay). */
+  glow?: boolean;
+  /** Render as a router `<Link to>`. */
+  to?: string;
+  /** Render as an `<a href>`. */
+  href?: string;
+  target?: string;
+  rel?: string;
+  className?: string;
+  children: React.ReactNode;
+  onClick?: React.MouseEventHandler;
+  "aria-label"?: string;
+}
+
+export function InteractiveCard({
+  accent = "var(--primary)",
+  glow = true,
+  to,
+  href,
+  target,
+  rel,
+  className,
+  children,
+  ...rest
+}: InteractiveCardProps) {
+  const reduced = useReducedMotion();
+  const canHover = useMediaQuery("(hover: hover) and (pointer: fine)");
+
+  const mx = useMotionValue(0);
+  const my = useMotionValue(0);
+  const background = useMotionTemplate`radial-gradient(240px circle at ${mx}px ${my}px, ${accent}, transparent 70%)`;
+
+  const enableHover = canHover && !reduced;
+  const enableTap = !reduced;
+
+  const handlePointerMove = enableHover
+    ? (e: React.PointerEvent<HTMLElement>) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        mx.set(e.clientX - rect.left);
+        my.set(e.clientY - rect.top);
+      }
+    : undefined;
+
+  // `group group/card`: the unnamed group keeps consumers' existing
+  // `group-hover:` utilities working when InteractiveCard replaces their Link;
+  // `group/card` drives the glow opacity independently.
+  const motionProps = {
+    className: cn("group group/card relative", className),
+    onPointerMove: handlePointerMove,
+    whileHover: enableHover ? { y: -3, scale: 1.02 } : undefined,
+    whileTap: enableTap ? { scale: 0.97 } : undefined,
+    transition: SPRING,
+    ...rest,
+  };
+
+  const overlay =
+    enableHover && glow ? (
+      <motion.span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-0 transition-opacity duration-300 group-hover/card:opacity-[0.16]"
+        style={{ background }}
+      />
+    ) : null;
+
+  if (to) {
+    return (
+      <MotionLink to={to} {...motionProps}>
+        {overlay}
+        {children}
+      </MotionLink>
+    );
+  }
+  if (href) {
+    return (
+      <motion.a href={href} target={target} rel={rel} {...motionProps}>
+        {overlay}
+        {children}
+      </motion.a>
+    );
+  }
+  return (
+    <motion.div {...motionProps}>
+      {overlay}
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/editorial/index.tsx
+++ b/src/components/editorial/index.tsx
@@ -11,6 +11,8 @@
 import { useEffect, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 
+export { InteractiveCard } from "./InteractiveCard";
+
 // ────────────────────────────────────────────────────────────────────────────
 // EditorialTitle
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import {
   EditorialTitle,
   StaggerGrid,
   StaggerItem,
+  InteractiveCard,
   useCountUp,
   Divider,
 } from "@/components/editorial";
@@ -669,11 +670,13 @@ export function HomePage() {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <StaggerGrid className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             {suggested.map((w) => (
-              <WorkoutCard key={w.id} workout={w} />
+              <StaggerItem key={w.id}>
+                <WorkoutCard workout={w} />
+              </StaggerItem>
             ))}
-          </div>
+          </StaggerGrid>
         </div>
       </section>
 
@@ -859,7 +862,7 @@ export function HomePage() {
             const href = r.source.url ?? "/methodology";
             const isExternal = !!r.source.url;
             const cls =
-              "group block border border-border bg-card hover:border-foreground/40 hover:-translate-y-0.5 hover:shadow-sm transition-all duration-200 p-3 rounded-md flex flex-col h-full";
+              "block border border-border bg-card hover:border-foreground/40 hover:shadow-sm transition-[box-shadow,border-color] duration-200 p-3 rounded-md flex flex-col h-full";
             const content = (
               <>
                 <span
@@ -878,18 +881,18 @@ export function HomePage() {
             return (
               <StaggerItem key={r.name}>
                 {isExternal ? (
-                  <a
+                  <InteractiveCard
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"
                     className={cls}
                   >
                     {content}
-                  </a>
+                  </InteractiveCard>
                 ) : (
-                  <Link to={href} className={cls}>
+                  <InteractiveCard to={href} className={cls}>
                     {content}
-                  </Link>
+                  </InteractiveCard>
                 )}
               </StaggerItem>
             );
@@ -938,9 +941,9 @@ export function HomePage() {
         <StaggerGrid className="md:hidden mt-10 grid grid-cols-2 gap-3">
           {planRows.map(({ key, plan }) => (
             <StaggerItem key={key}>
-              <Link
+              <InteractiveCard
                 to={`/plan/prebuilt/${plan.slug}`}
-                className="group block border border-border bg-card hover:border-foreground/40 hover:-translate-y-0.5 hover:shadow-sm transition-all duration-200 p-3 rounded-md flex flex-col gap-3 h-full"
+                className="block border border-border bg-card hover:border-foreground/40 hover:shadow-sm transition-[box-shadow,border-color] duration-200 p-3 rounded-md flex flex-col gap-3 h-full"
               >
                 <div className="flex items-center gap-2">
                   <span className="text-base font-sans italic font-semibold flex-1 leading-snug group-hover:text-primary transition-colors">
@@ -967,7 +970,7 @@ export function HomePage() {
                 <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-muted-foreground -mt-1">
                   {plan.totalWeeks} {t("homepage:home.s05.weeks")}
                 </div>
-              </Link>
+              </InteractiveCard>
             </StaggerItem>
           ))}
         </StaggerGrid>
@@ -1003,9 +1006,9 @@ export function HomePage() {
         <StaggerGrid className="mt-10 grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 gap-2 sm:gap-3">
           {CALCULATORS.map((c) => (
             <StaggerItem key={c.key}>
-              <Link
+              <InteractiveCard
                 to={c.slug}
-                className="group block border border-border bg-card hover:border-foreground/40 hover:-translate-y-0.5 hover:shadow-sm transition-all duration-200 p-3 sm:p-5 rounded-md flex items-center sm:block gap-2 sm:gap-0"
+                className="block border border-border bg-card hover:border-foreground/40 hover:shadow-sm transition-[box-shadow,border-color] duration-200 p-3 sm:p-5 rounded-md flex items-center sm:block gap-2 sm:gap-0"
               >
                 <h3 className="text-sm sm:text-base font-semibold sm:mb-1.5 group-hover:text-primary transition-colors flex-1 sm:flex-none leading-snug">
                   {t(c.titleKey)}
@@ -1018,7 +1021,7 @@ export function HomePage() {
                   <ArrowRight className="size-3 ml-1 transition-transform group-hover:translate-x-0.5" />
                 </span>
                 <ArrowRight className="size-4 sm:hidden text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
-              </Link>
+              </InteractiveCard>
             </StaggerItem>
           ))}
         </StaggerGrid>


### PR DESCRIPTION
Introduce a shared InteractiveCard motion shell and apply it across the
app's card grids so cards feel alive, not static — while staying within
the restrained editorial aesthetic.

- Tap feedback (whileTap spring) is the primary interaction and runs on
  every device, since ~95% of traffic is touch.
- Cursor-following spotlight glow (tinted by the card's zone/category
  accent) and a spring lift are progressive enhancement, mounted only on
  hover-capable, fine-pointer devices so touch never pays for pointer math.
- Fully honors prefers-reduced-motion (renders static).

Built natively on the framer-motion already shipped (useMotionValue +
useMotionTemplate), no new dependency. Applied to WorkoutCard,
CollectionCard, ArticleCard, PrebuiltPlanCard and the homepage bento
grids (researchers, plans, calculators); §02 suggestions now stagger in.

https://claude.ai/code/session_01EozE2H45nxGEc1hLwnhGu7