### PR TITLE
feat(search): extend Command Palette to more product surfaces (#60)

### DIFF
--- a/src/components/search/CommandPalette.tsx
+++ b/src/components/search/CommandPalette.tsx
@@ -1,15 +1,53 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Search, X, Loader2, ArrowRight, BookOpen, Book, Dumbbell } from "@/components/icons";
+import {
+  Search,
+  X,
+  Loader2,
+  ArrowRight,
+  BookOpen,
+  Book,
+  Dumbbell,
+  Library,
+  Calculator,
+  Compass,
+  Sparkles,
+} from "@/components/icons";
 import { Dialog, DialogPortal, DialogOverlay, DialogTitle } from "@/components/ui/dialog";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { useCommandPalette } from "./CommandPaletteProvider";
 import { SearchResultItem } from "./SearchResultItem";
-import { unifiedSearch, type UnifiedSearchResult, type UnifiedSearchResults } from "@/lib/unified-search";
+import {
+  unifiedSearch,
+  type SearchResultType,
+  type UnifiedSearchResult,
+  type UnifiedSearchResults,
+} from "@/lib/unified-search";
+import { FEATURED_SURFACES, type SurfaceSection } from "@/data/command-surfaces";
 import { getWorkoutById } from "@/data/workouts";
 import type { AnyWorkoutTemplate } from "@/types";
 import { cn } from "@/lib/utils";
+
+type IconComponent = React.ComponentType<{ className?: string }>;
+
+/** Icon shown next to a generic result, by result type. */
+const TYPE_ICON: Record<SearchResultType, IconComponent> = {
+  workout: Dumbbell,
+  collection: Library,
+  calculator: Calculator,
+  guide: Compass,
+  article: BookOpen,
+  glossary: Book,
+  page: Sparkles,
+};
+
+/** Maps a static surface section to a result type (for the quick-access list). */
+const SURFACE_TYPE: Record<SurfaceSection, SearchResultType> = {
+  calculator: "calculator",
+  guide: "guide",
+  page: "page",
+};
 
 const DEBOUNCE_MS = 150;
 const MAX_PER_TYPE = 5;
@@ -58,6 +96,7 @@ export function CommandPalette() {
     if (!query.trim()) {
       setSearchResults(null);
       setIsLoading(false);
+      setSelectedIndex(0);
       return;
     }
 
@@ -83,9 +122,35 @@ export function CommandPalette() {
 
   // Build flat list of selectable items (skip headers for navigation)
   const { flatItems, selectableItems } = useMemo(() => {
+    const items: FlatItem[] = [];
+
+    // Empty state: surface a few featured destinations for quick access.
+    if (!query.trim()) {
+      const en = i18n.language.startsWith("en");
+      items.push({ kind: "header", label: t("search.sections.quickAccess"), icon: Sparkles });
+      for (const s of FEATURED_SURFACES) {
+        items.push({
+          kind: "generic",
+          result: {
+            type: SURFACE_TYPE[s.section],
+            id: s.id,
+            title: en ? s.titleEn : s.title,
+            subtitle: en ? s.subtitleEn : s.subtitle,
+            url: s.url,
+          },
+        });
+      }
+      const selectable = items.filter((i) => i.kind !== "header");
+      return { flatItems: items, selectableItems: selectable };
+    }
+
     if (!searchResults) return { flatItems: [] as FlatItem[], selectableItems: [] as FlatItem[] };
 
-    const items: FlatItem[] = [];
+    const addGeneric = (results: UnifiedSearchResult[], label: string, icon: IconComponent) => {
+      if (results.length === 0) return;
+      items.push({ kind: "header", label, icon });
+      for (const r of results) items.push({ kind: "generic", result: r });
+    };
 
     if (searchResults.workouts.length > 0) {
       items.push({ kind: "header", label: t("search.sections.workouts"), icon: Dumbbell });
@@ -95,23 +160,16 @@ export function CommandPalette() {
       }
     }
 
-    if (searchResults.articles.length > 0) {
-      items.push({ kind: "header", label: t("search.sections.articles"), icon: BookOpen });
-      for (const r of searchResults.articles) {
-        items.push({ kind: "generic", result: r });
-      }
-    }
-
-    if (searchResults.glossary.length > 0) {
-      items.push({ kind: "header", label: t("search.sections.glossary"), icon: Book });
-      for (const r of searchResults.glossary) {
-        items.push({ kind: "generic", result: r });
-      }
-    }
+    addGeneric(searchResults.collections, t("search.sections.collections"), Library);
+    addGeneric(searchResults.calculators, t("search.sections.calculators"), Calculator);
+    addGeneric(searchResults.guides, t("search.sections.guides"), Compass);
+    addGeneric(searchResults.articles, t("search.sections.articles"), BookOpen);
+    addGeneric(searchResults.glossary, t("search.sections.glossary"), Book);
+    addGeneric(searchResults.pages, t("search.sections.pages"), Sparkles);
 
     const selectable = items.filter((i) => i.kind !== "header");
     return { flatItems: items, selectableItems: selectable };
-  }, [searchResults, workoutCache, t]);
+  }, [searchResults, workoutCache, query, i18n.language, t]);
 
   // Scroll selected item into view
   useEffect(() => {
@@ -226,13 +284,6 @@ export function CommandPalette() {
 
           {/* Results */}
           <div className="flex-1 overflow-y-auto p-2" ref={resultsRef} aria-live="polite" aria-atomic="false">
-            {/* No query - hint */}
-            {!query.trim() && (
-              <div className="px-3 py-8 text-center text-sm text-muted-foreground">
-                {t("search.placeholder")}
-              </div>
-            )}
-
             {/* Loading state */}
             {query.trim() && isLoading && (
               <div className="px-3 py-8 text-center">
@@ -278,8 +329,8 @@ export function CommandPalette() {
                   );
                 }
 
-                // Generic result (article or glossary)
-                const Icon = item.result.type === "article" ? BookOpen : Book;
+                // Generic result (collection, calculator, guide, article, glossary, page)
+                const Icon = TYPE_ICON[item.result.type];
                 return (
                   <button
                     key={item.result.id}

--- a/src/data/command-surfaces.ts
+++ b/src/data/command-surfaces.ts
@@ -1,0 +1,368 @@
+// src/data/command-surfaces.ts
+// Static registry of navigable product surfaces (tools, guides, pages) surfaced
+// in the Command Palette. Each entry is a directly-navigable destination — no
+// heuristics. Titles/subtitles are stored inline FR/EN (same pattern as
+// CALCULATEURS and collections data) so this module stays light and free of
+// page-component imports.
+
+import { normalizeSearch } from "@/lib/search-utils";
+
+export type SurfaceSection = "calculator" | "guide" | "page";
+
+export interface CommandSurface {
+  id: string;
+  section: SurfaceSection;
+  title: string;
+  titleEn: string;
+  subtitle: string;
+  subtitleEn: string;
+  url: string;
+  /** FR + EN terms so users can type a product need (e.g. "nutrition", "trail"). */
+  keywords: string[];
+  /** Surfaced in the empty-state "quick access" list. */
+  featured?: boolean;
+}
+
+export const COMMAND_SURFACES: CommandSurface[] = [
+  // --- Calculateurs (titles mirror CALCULATEURS in CalculateursPage) ---
+  {
+    id: "calculators",
+    section: "calculator",
+    title: "Calculateurs",
+    titleEn: "Calculators",
+    subtitle: "Tous les outils de calcul et de conversion",
+    subtitleEn: "All calculation and conversion tools",
+    url: "/calculators",
+    keywords: ["calculateur", "calculator", "outils", "tools", "convertir", "convert"],
+    featured: true,
+  },
+  {
+    id: "calc-zones",
+    section: "calculator",
+    title: "Zones d'entraînement",
+    titleEn: "Training Zones",
+    subtitle: "Calculez vos zones FC et allures depuis votre VMA ou FCmax",
+    subtitleEn: "Calculate your HR and pace zones from VMA or max HR",
+    url: "/calculators/zones",
+    keywords: ["zones", "fc", "fcmax", "vma", "heart rate", "frequence cardiaque", "allures"],
+  },
+  {
+    id: "calc-vma",
+    section: "calculator",
+    title: "VMA depuis un chrono",
+    titleEn: "VMA from Race Time",
+    subtitle: "Estimez votre VMA à partir d'un résultat de course",
+    subtitleEn: "Estimate your VMA from a race result",
+    url: "/calculators/vma",
+    keywords: ["vma", "vo2max", "vitesse maximale aerobie", "chrono", "race time"],
+  },
+  {
+    id: "calc-ftp",
+    section: "calculator",
+    title: "Test FTP vélo",
+    titleEn: "FTP Cycling Test",
+    subtitle: "Estimez votre FTP depuis un test 20 minutes ou un ramp test",
+    subtitleEn: "Estimate your FTP from a 20-minute or ramp test",
+    url: "/calculators/ftp",
+    keywords: ["ftp", "velo", "cycling", "cyclisme", "watts", "puissance", "power", "ramp test"],
+  },
+  {
+    id: "calc-css",
+    section: "calculator",
+    title: "Test CSS natation",
+    titleEn: "CSS Swimming Test",
+    subtitle: "Estimez votre CSS depuis un test 400m + 200m",
+    subtitleEn: "Estimate your CSS from a 400m + 200m test",
+    url: "/calculators/css",
+    keywords: ["css", "natation", "swimming", "swim", "critical swim speed", "nage"],
+  },
+  {
+    id: "calc-allures",
+    section: "calculator",
+    title: "Convertisseur d'allures",
+    titleEn: "Pace Converter",
+    subtitle: "Convertissez entre min/km, km/h et min/mile en temps réel",
+    subtitleEn: "Convert between min/km, km/h and min/mile in real time",
+    url: "/calculators/convertisseur",
+    keywords: ["allure", "pace", "convertisseur", "converter", "min/km", "km/h", "mile"],
+  },
+  {
+    id: "calc-table-allures",
+    section: "calculator",
+    title: "Table de référence",
+    titleEn: "Pace Reference Table",
+    subtitle: "Toutes les allures de 3:00 à 10:00/km avec temps estimés",
+    subtitleEn: "All paces from 3:00 to 10:00/km with estimated times",
+    url: "/calculators/table-allures",
+    keywords: ["table", "allures", "pace table", "reference", "temps", "splits"],
+  },
+  {
+    id: "calc-tapis",
+    section: "calculator",
+    title: "Convertisseur tapis roulant",
+    titleEn: "Treadmill Converter",
+    subtitle: "Convertissez vitesse et inclinaison en allure équivalente",
+    subtitleEn: "Convert speed and incline to equivalent pace",
+    url: "/calculators/tapis-roulant",
+    keywords: ["tapis", "treadmill", "inclinaison", "incline", "vitesse", "indoor"],
+  },
+  {
+    id: "calc-splits",
+    section: "calculator",
+    title: "Générateur de splits",
+    titleEn: "Split Generator",
+    subtitle: "Planifiez vos passages pour atteindre votre objectif chrono",
+    subtitleEn: "Plan your splits to reach your target time",
+    url: "/calculators/splits",
+    keywords: ["splits", "passages", "objectif", "chrono", "negative split", "pacing"],
+  },
+  {
+    id: "calc-equivalence",
+    section: "calculator",
+    title: "Équivalence entre distances",
+    titleEn: "Race Equivalence",
+    subtitle: "Prédisez vos temps sur toutes les distances depuis un résultat",
+    subtitleEn: "Predict your times across all distances from one result",
+    url: "/calculators/equivalence",
+    keywords: ["equivalence", "prediction", "distances", "5k", "10k", "semi", "marathon", "predict"],
+  },
+  {
+    id: "calc-age-graded",
+    section: "calculator",
+    title: "Performance age-graded",
+    titleEn: "Age-Graded Performance",
+    subtitle: "Comparez votre performance au record mondial de votre catégorie",
+    subtitleEn: "Compare your performance to the world record for your category",
+    url: "/calculators/age-graded",
+    keywords: ["age", "age-graded", "performance", "record", "categorie", "wma"],
+  },
+  {
+    id: "calc-race-simulator",
+    section: "calculator",
+    title: "Simulateur jour de course",
+    titleEn: "Race Day Simulator",
+    subtitle: "Plan complet jour de course : horaires, allures, nutrition, mental",
+    subtitleEn: "Complete race day plan: schedule, pacing, nutrition, mental cues",
+    url: "/race-simulator",
+    keywords: ["course", "race", "simulateur", "simulator", "objectif", "chrono", "pacing", "negative split", "jour j"],
+    featured: true,
+  },
+  {
+    id: "calc-what-if",
+    section: "calculator",
+    title: "Simulateur What-If",
+    titleEn: "What-If Simulator",
+    subtitle: "Comparez deux scénarios d'entraînement et visualisez les différences",
+    subtitleEn: "Compare two training scenarios and visualize the differences",
+    url: "/calculators/what-if",
+    keywords: ["what-if", "scenario", "comparer", "compare", "simulation"],
+  },
+
+  // --- Guides ---
+  {
+    id: "guides",
+    section: "guide",
+    title: "Guides",
+    titleEn: "Guides",
+    subtitle: "Guides pratiques : nutrition, préparation course, échauffement",
+    subtitleEn: "Practical guides: nutrition, race prep, warmup",
+    url: "/guides",
+    keywords: ["guide", "guides", "pratique", "how to", "tutoriel"],
+    featured: true,
+  },
+  {
+    id: "guide-nutrition",
+    section: "guide",
+    title: "Guide nutrition",
+    titleEn: "Nutrition Guide",
+    subtitle: "Alimentation, hydratation et ravitaillement en course",
+    subtitleEn: "Fueling, hydration and race-day nutrition",
+    url: "/guides/nutrition",
+    keywords: ["nutrition", "alimentation", "hydratation", "glucides", "ravitaillement", "carbs", "fueling", "gels"],
+  },
+  {
+    id: "guide-race-prep",
+    section: "guide",
+    title: "Guide préparation course",
+    titleEn: "Race Prep Guide",
+    subtitle: "Checklist, stratégie et récupération autour de la course",
+    subtitleEn: "Checklist, strategy and recovery around race day",
+    url: "/guides/race-prep",
+    keywords: ["preparation", "course", "race prep", "checklist", "strategie", "taper", "affutage"],
+  },
+  {
+    id: "guide-warmup",
+    section: "guide",
+    title: "Guide échauffement",
+    titleEn: "Warmup Guide",
+    subtitle: "Routines d'échauffement et retour au calme",
+    subtitleEn: "Warmup routines and cool-down",
+    url: "/guides/warmup",
+    keywords: ["echauffement", "warmup", "warm up", "retour au calme", "cool down", "mobilite", "etirements"],
+  },
+  {
+    id: "nutrition-hub",
+    section: "guide",
+    title: "Nutrition",
+    titleEn: "Nutrition",
+    subtitle: "Tout sur la nutrition du coureur",
+    subtitleEn: "Everything about runner nutrition",
+    url: "/nutrition",
+    keywords: ["nutrition", "alimentation", "hydratation", "glucides", "carbs", "energie"],
+  },
+
+  // --- Pages / outils ---
+  {
+    id: "settings",
+    section: "page",
+    title: "Paramètres",
+    titleEn: "Settings",
+    subtitle: "Langue, thème, unités et préférences",
+    subtitleEn: "Language, theme, units and preferences",
+    url: "/settings",
+    keywords: ["parametres", "settings", "preferences", "langue", "language", "theme", "unites", "units", "reglages"],
+    featured: true,
+  },
+  {
+    id: "contribute",
+    section: "page",
+    title: "Contribuer",
+    titleEn: "Contribute",
+    subtitle: "Proposez du contenu, signalez un bug, donnez votre avis",
+    subtitleEn: "Suggest content, report a bug, share feedback",
+    url: "/contribute",
+    keywords: ["contribuer", "contribute", "github", "feedback", "suggestion", "bug", "avis", "proposer"],
+    featured: true,
+  },
+  {
+    id: "plans",
+    section: "page",
+    title: "Mes plans",
+    titleEn: "My Plans",
+    subtitle: "Vos plans d'entraînement personnalisés",
+    subtitleEn: "Your personalized training plans",
+    url: "/plans",
+    keywords: ["plan", "plans", "entrainement", "training", "programme"],
+    featured: true,
+  },
+  {
+    id: "plan-new",
+    section: "page",
+    title: "Créer un plan",
+    titleEn: "Create a Plan",
+    subtitle: "Démarrez un nouveau plan d'entraînement",
+    subtitleEn: "Start a new training plan",
+    url: "/plan/new",
+    keywords: ["nouveau plan", "creer", "create", "new plan", "assisted", "prebuilt", "generer"],
+  },
+  {
+    id: "plan-methodology",
+    section: "page",
+    title: "Méthodologie des plans",
+    titleEn: "Plan Methodology",
+    subtitle: "Comment nos plans d'entraînement sont construits",
+    subtitleEn: "How our training plans are built",
+    url: "/plans/methodology",
+    keywords: ["methodologie", "methodology", "plans", "periodisation", "construction"],
+  },
+  {
+    id: "methodology",
+    section: "page",
+    title: "Méthodologie",
+    titleEn: "Methodology",
+    subtitle: "La science derrière Zoned",
+    subtitleEn: "The science behind Zoned",
+    url: "/methodology",
+    keywords: ["methodologie", "methodology", "science", "references", "sources"],
+  },
+  {
+    id: "compare",
+    section: "page",
+    title: "Comparatifs",
+    titleEn: "Compare",
+    subtitle: "Comparez Zoned aux autres outils d'entraînement",
+    subtitleEn: "Compare Zoned to other training tools",
+    url: "/compare",
+    keywords: ["comparer", "compare", "comparatif", "vs", "alternative", "concurrents"],
+  },
+  {
+    id: "profile",
+    section: "page",
+    title: "Profil coureur",
+    titleEn: "Runner Profile",
+    subtitle: "Vos données, niveaux et records personnels",
+    subtitleEn: "Your data, levels and personal records",
+    url: "/profile",
+    keywords: ["profil", "profile", "coureur", "runner", "records", "niveau"],
+  },
+  {
+    id: "favorites",
+    section: "page",
+    title: "Favoris",
+    titleEn: "Favorites",
+    subtitle: "Vos séances et contenus enregistrés",
+    subtitleEn: "Your saved workouts and content",
+    url: "/favorites",
+    keywords: ["favoris", "favorites", "enregistres", "saved", "bookmarks"],
+  },
+  {
+    id: "routes",
+    section: "page",
+    title: "Parcours",
+    titleEn: "Routes",
+    subtitle: "Générez et explorez des parcours de course",
+    subtitleEn: "Generate and explore running routes",
+    url: "/routes",
+    keywords: ["parcours", "routes", "trail", "itineraire", "carte", "map", "gpx"],
+  },
+  {
+    id: "quiz",
+    section: "page",
+    title: "Quiz",
+    titleEn: "Quiz",
+    subtitle: "Testez vos connaissances en entraînement",
+    subtitleEn: "Test your training knowledge",
+    url: "/quiz",
+    keywords: ["quiz", "test", "connaissances", "questions"],
+  },
+  {
+    id: "changelog",
+    section: "page",
+    title: "Nouveautés",
+    titleEn: "Changelog",
+    subtitle: "Les dernières mises à jour de Zoned",
+    subtitleEn: "The latest Zoned updates",
+    url: "/changelog",
+    keywords: ["changelog", "nouveautes", "updates", "releases", "versions", "what's new"],
+  },
+  {
+    id: "about",
+    section: "page",
+    title: "À propos",
+    titleEn: "About",
+    subtitle: "En savoir plus sur Zoned",
+    subtitleEn: "Learn more about Zoned",
+    url: "/about",
+    keywords: ["a propos", "about", "zoned", "qui", "projet"],
+  },
+];
+
+/** Surfaces shown in the empty-state quick-access list, in registry order. */
+export const FEATURED_SURFACES: CommandSurface[] = COMMAND_SURFACES.filter(
+  (s) => s.featured,
+);
+
+/**
+ * Filter navigable surfaces by query (diacritic-insensitive), matching against
+ * title, subtitle and keywords in both languages.
+ */
+export function searchSurfaces(query: string): CommandSurface[] {
+  const q = normalizeSearch(query.trim());
+  if (!q) return [];
+  return COMMAND_SURFACES.filter((s) => {
+    const haystack = normalizeSearch(
+      [s.title, s.titleEn, s.subtitle, s.subtitleEn, ...s.keywords].join(" "),
+    );
+    return haystack.includes(q);
+  });
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -413,14 +413,19 @@
     }
   },
   "search": {
-    "placeholder": "Search workouts, articles, glossary...",
+    "placeholder": "Search workouts, tools, guides, pages...",
     "shortcut": "Cmd+K",
     "noResults": "No results found",
     "viewAll": "View all in Library",
     "sections": {
+      "quickAccess": "Quick access",
       "workouts": "Workouts",
+      "collections": "Collections",
+      "calculators": "Calculators",
+      "guides": "Guides",
       "articles": "Articles",
-      "glossary": "Glossary"
+      "glossary": "Glossary",
+      "pages": "Pages"
     }
   },
   "relatedContent": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -413,14 +413,19 @@
     }
   },
   "search": {
-    "placeholder": "Rechercher séances, articles, glossaire...",
+    "placeholder": "Rechercher séances, outils, guides, pages...",
     "shortcut": "Cmd+K",
     "noResults": "Aucun résultat trouvé",
     "viewAll": "Voir tout dans la bibliothèque",
     "sections": {
+      "quickAccess": "Accès rapide",
       "workouts": "Séances",
+      "collections": "Collections",
+      "calculators": "Calculateurs",
+      "guides": "Guides",
       "articles": "Articles",
-      "glossary": "Glossaire"
+      "glossary": "Glossaire",
+      "pages": "Pages"
     }
   },
   "relatedContent": {

--- a/src/lib/unified-search.ts
+++ b/src/lib/unified-search.ts
@@ -1,13 +1,23 @@
 // src/lib/unified-search.ts
-// Unified search across workouts, articles, and glossary terms
+// Unified search across workouts, collections, calculators, guides, articles,
+// glossary terms and navigable product pages.
 
 import { searchWorkouts } from "@/data/workouts";
 import { searchStrengthSessions } from "@/data/strength";
 import { getAllArticleMeta } from "@/data/articles/metadata";
 import { loadAllTerms } from "@/data/glossary";
+import { getAllCollections } from "@/data/collections";
+import { searchSurfaces, type SurfaceSection } from "@/data/command-surfaces";
 import { normalizeSearch } from "@/lib/search-utils";
 
-export type SearchResultType = "workout" | "article" | "glossary";
+export type SearchResultType =
+  | "workout"
+  | "collection"
+  | "calculator"
+  | "guide"
+  | "article"
+  | "glossary"
+  | "page";
 
 export interface UnifiedSearchResult {
   type: SearchResultType;
@@ -19,10 +29,32 @@ export interface UnifiedSearchResult {
 
 export interface UnifiedSearchResults {
   workouts: UnifiedSearchResult[];
+  collections: UnifiedSearchResult[];
+  calculators: UnifiedSearchResult[];
+  guides: UnifiedSearchResult[];
   articles: UnifiedSearchResult[];
   glossary: UnifiedSearchResult[];
+  pages: UnifiedSearchResult[];
   total: number;
 }
+
+/** Maps a static surface section to the result type used by the palette. */
+const SURFACE_SECTION_TYPE: Record<SurfaceSection, SearchResultType> = {
+  calculator: "calculator",
+  guide: "guide",
+  page: "page",
+};
+
+const emptyResults = (): UnifiedSearchResults => ({
+  workouts: [],
+  collections: [],
+  calculators: [],
+  guides: [],
+  articles: [],
+  glossary: [],
+  pages: [],
+  total: 0,
+});
 
 const isEn = (lang: string): boolean => lang.startsWith("en");
 
@@ -33,7 +65,7 @@ export async function unifiedSearch(
 ): Promise<UnifiedSearchResults> {
   const trimmed = query.trim();
   if (!trimmed) {
-    return { workouts: [], articles: [], glossary: [], total: 0 };
+    return emptyResults();
   }
 
   const lowerQuery = normalizeSearch(trimmed);
@@ -119,10 +151,58 @@ export async function unifiedSearch(
       url: `/glossary/${t.id}`,
     }));
 
+  // --- Collections ---
+  const matchingCollections = getAllCollections().filter((c) => {
+    const searchable = normalizeSearch(
+      [c.name, c.nameEn, c.description, c.descriptionEn, ...c.tags].join(" ")
+    );
+    return searchable.includes(lowerQuery);
+  });
+
+  const collections: UnifiedSearchResult[] = matchingCollections
+    .slice(0, maxPerType)
+    .map((c) => ({
+      type: "collection" as const,
+      id: c.id,
+      title: en ? c.nameEn : c.name,
+      subtitle: en ? c.descriptionEn : c.description,
+      url: `/collections/${c.slug}`,
+    }));
+
+  // --- Navigable surfaces (calculators / guides / pages) ---
+  const surfaces = searchSurfaces(trimmed);
+  const calculators: UnifiedSearchResult[] = [];
+  const guides: UnifiedSearchResult[] = [];
+  const pages: UnifiedSearchResult[] = [];
+
+  for (const s of surfaces) {
+    const result: UnifiedSearchResult = {
+      type: SURFACE_SECTION_TYPE[s.section],
+      id: s.id,
+      title: en ? s.titleEn : s.title,
+      subtitle: en ? s.subtitleEn : s.subtitle,
+      url: s.url,
+    };
+    const bucket =
+      s.section === "calculator" ? calculators : s.section === "guide" ? guides : pages;
+    if (bucket.length < maxPerType) bucket.push(result);
+  }
+
   return {
     workouts,
+    collections,
+    calculators,
+    guides,
     articles,
     glossary,
-    total: workouts.length + articles.length + glossary.length,
+    pages,
+    total:
+      workouts.length +
+      collections.length +
+      calculators.length +
+      guides.length +
+      articles.length +
+      glossary.length +
+      pages.length,
   };
 }


### PR DESCRIPTION
Turn the Cmd+K palette into a product-wide navigation hub.

- Add a static registry of navigable surfaces (src/data/command-surfaces.ts):
  calculators + race simulator, guides, and utility pages (settings,
  contribute, plans, methodology, compare, profile, routes, ...). Each entry
  carries FR/EN title/subtitle plus keywords so users can type a product
  need (nutrition, trail, settings, ftp) and land on the right surface.
- Extend unifiedSearch with collection, calculator, guide and page result
  types, reusing existing collections data and normalizeSearch. Results stay
  grouped by type and capped per section to avoid a noisy directory.
- CommandPalette now renders clear per-type sections with icons, a type->icon
  map, and a keyboard-navigable "Quick access" empty state built from the
  featured surfaces.
- Add i18n section labels (collections, calculators, guides, pages,
  quickAccess) and richer placeholder in FR/EN.