### PR TITLE
feat(theme,pwa): follow the system theme, and offer updates instead of forcing them

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,12 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" sizes="180x180" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <!-- One theme-color, deliberately WITHOUT `media`. A media-scoped meta
+         follows the OS, so a user who forces light on a dark phone would keep a
+         dark system bar. The inline script below and `applyResolvedTheme` in
+         src/lib/theme.ts both write this tag; the value here is the light
+         default they start from. -->
+    <meta name="theme-color" content="#f8fafc" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="application-name" content="Zoned" />
     <meta name="apple-mobile-web-app-title" content="Zoned" />
@@ -81,13 +85,30 @@
       crossorigin
     />
 
-    <!-- Theme sync script - MUST run before any render to prevent flash -->
+    <!-- Theme sync script - MUST run before any render to prevent flash.
+         Inline, synchronous, not a module and not deferred: it has to finish
+         before the browser paints. That is why it duplicates the logic of
+         src/lib/theme.ts rather than importing it, and why the preference is
+         stored as a bare string — one getItem, no JSON.parse.
+         The two hex values mirror THEME_COLOR in src/lib/theme.ts, itself a
+         mirror of --background in src/styles/themes.css. -->
     <script>
       (function() {
-        var stored = localStorage.getItem('zoned-theme');
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        var isDark = stored === 'dark' || (!stored && prefersDark);
-        if (isDark) document.documentElement.classList.add('dark');
+        try {
+          var raw = localStorage.getItem('zoned-theme');
+          var pref = (raw === 'light' || raw === 'dark' || raw === 'system') ? raw : 'system';
+          var isDark = pref === 'dark' ||
+            (pref === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          // toggle, not add: the class may already be there after a bfcache restore.
+          document.documentElement.classList.toggle('dark', isDark);
+          // Native controls — scrollbars, date pickers, autofill.
+          document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+          var meta = document.querySelector('meta[name="theme-color"]:not([media])');
+          if (meta) meta.setAttribute('content', isDark ? '#0b1120' : '#f8fafc');
+        } catch (e) {
+          // Private mode can throw on localStorage. Paint light and carry on.
+          document.documentElement.classList.remove('dark');
+        }
       })();
     </script>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
-import { useState, useEffect, useRef, useCallback, lazy, Suspense, type ComponentType } from "react";
+import { useState, useEffect, useRef, lazy, Suspense, type ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 import { Analytics } from "@vercel/analytics/react";
 import { toast, Toaster } from "sonner";
@@ -11,7 +11,9 @@ import { CommandPaletteProvider, useCommandPalette } from "@/components/search";
 import { GlossaryMatcherProvider } from "@/contexts/GlossaryMatcherContext";
 import { StorageWarning } from "@/components/domain/StorageWarning";
 import { PWAInstallPrompt } from "@/components/domain/PWAInstallPrompt";
+import { UpdatePrompt } from "@/components/domain/UpdatePrompt";
 import { usePWA } from "@/hooks/usePWA";
+import { ThemeProvider } from "@/hooks/useTheme";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useIdleAfterLoad } from "@/hooks/useIdleAfterLoad";
 import { i18nReady } from "@/i18n";
@@ -174,7 +176,7 @@ function ScrollToTopOnNavigate() {
 
 function App() {
   const { t } = useTranslation("common");
-  const { canInstall, promptInstall, dismissInstall, isOnline, updateAvailable, applyUpdate } = usePWA();
+  const { canInstall, promptInstall, dismissInstall, isOnline } = usePWA();
   // Toaster placement: bottom-right covers the share-sheet action row on
   // mobile (Copier / Partager / Télécharger). On small viewports we surface
   // the toast at the top instead so it never overlaps a button the user just
@@ -189,51 +191,9 @@ function App() {
     if (preloadReady) preloadSidebarPages();
   }, [preloadReady]);
 
-  // Track if user has manually set theme preference
-  const userHasSetTheme = useRef(
-    typeof window !== "undefined" && localStorage.getItem("zoned-theme") !== null
-  );
-
-  // Theme — managed via ref + DOM to avoid re-rendering the entire app tree.
-  // Only the TopBar icon needs to know the current theme (handled via its own state).
-  const themeRef = useRef<"light" | "dark">(
-    (() => {
-      if (typeof window !== "undefined") {
-        const stored = localStorage.getItem("zoned-theme");
-        if (stored === "dark" || stored === "light") return stored;
-        if (window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
-      }
-      return "light" as const;
-    })()
-  );
-
-  // Apply initial theme (no state involved)
-  useEffect(() => {
-    document.documentElement.classList.toggle("dark", themeRef.current === "dark");
-  }, []);
-
-  // Listen for system theme changes
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const handleChange = (e: MediaQueryListEvent) => {
-      if (!userHasSetTheme.current) {
-        themeRef.current = e.matches ? "dark" : "light";
-        document.documentElement.classList.toggle("dark", themeRef.current === "dark");
-      }
-    };
-    mediaQuery.addEventListener("change", handleChange);
-    return () => mediaQuery.removeEventListener("change", handleChange);
-  }, []);
-
-  // PWA: toast on update available
-  useEffect(() => {
-    if (updateAvailable) {
-      toast(t("pwa.updateAvailable"), {
-        action: { label: t("pwa.update"), onClick: applyUpdate },
-        duration: Infinity,
-      });
-    }
-  }, [updateAvailable]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Theme lives in ThemeProvider (mounted below). Nothing here needs to know
+  // it: the TopBar button and the settings card read it from context, so a
+  // theme change never re-renders this tree.
 
   // PWA: toast on offline / back-online
   const prevOnline = useRef(true);
@@ -247,28 +207,11 @@ function App() {
     prevOnline.current = isOnline;
   }, [isOnline]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Toggle theme — NO setState, NO App re-render. Just DOM class + localStorage.
-  // Transitions are disabled during the switch to avoid border/background flash.
-  const toggleTheme = useCallback(() => {
-    userHasSetTheme.current = true;
-    document.documentElement.setAttribute("data-switching-theme", "");
-    const next = themeRef.current === "dark" ? "light" : "dark";
-    themeRef.current = next;
-    document.documentElement.classList.toggle("dark", next === "dark");
-    localStorage.setItem("zoned-theme", next);
-    // Dispatch custom event so TopBar can update its icon
-    window.dispatchEvent(new CustomEvent("zoned-theme-change", { detail: next }));
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        document.documentElement.removeAttribute("data-switching-theme");
-      });
-    });
-  }, []);
-
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   return (
     <SettingsProvider>
+      <ThemeProvider>
         <FavoritesProvider>
           <BrowserRouter>
           <GlossaryMatcherProvider>
@@ -281,10 +224,7 @@ function App() {
             </a>
             <ScrollToTopOnNavigate />
             <div className="min-h-screen bg-background text-foreground flex flex-col">
-              <TopBar
-                onThemeToggle={toggleTheme}
-                onMobileMenuOpen={() => setMobileSidebarOpen(true)}
-              />
+              <TopBar onMobileMenuOpen={() => setMobileSidebarOpen(true)} />
 
               {/* Mobile slide-over nav (hamburger). Desktop uses the
                   horizontal nav inside TopBar, no sidebar. */}
@@ -400,6 +340,9 @@ function App() {
           <Analytics />
           <StorageWarning />
           {canInstall && <PWAInstallPrompt onInstall={promptInstall} onDismiss={dismissInstall} />}
+          {/* Mounted once, outside <Routes>, so the banner survives navigation.
+              Stacked above the install card when both are eligible. */}
+          <UpdatePrompt stacked={canInstall} />
           <Toaster
             richColors
             closeButton
@@ -408,7 +351,8 @@ function App() {
             offset={isMobile ? "calc(env(safe-area-inset-top, 0px) + 12px)" : undefined}
           />
           </BrowserRouter>
-      </FavoritesProvider>
+        </FavoritesProvider>
+      </ThemeProvider>
     </SettingsProvider>
   );
 }

--- a/src/components/domain/UpdatePrompt.tsx
+++ b/src/components/domain/UpdatePrompt.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useRegisterSW } from "virtual:pwa-register/react";
+
+import { RefreshCw, X } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { watchForegroundUpdates } from "@/lib/swUpdate";
+
+interface Props {
+  /** Lift above the install card when that one is showing too. */
+  stacked?: boolean;
+}
+
+/**
+ * The service worker is registered in `prompt` mode: a new version installs in
+ * the background, waits, and never replaces the running app without being
+ * asked. Zoned keeps everything in the browser — plans, custom workouts,
+ * simulations — so a reload in the middle of an edit would cost real work.
+ *
+ * The button below is the only code path in the app that reloads. Everything
+ * else, including the check on returning to the foreground, only ever moves the
+ * moment this banner appears earlier.
+ */
+export function UpdatePrompt({ stacked = false }: Props) {
+  const { t } = useTranslation("common");
+  const registration = useRef<ServiceWorkerRegistration | null>(null);
+
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    immediate: true,
+    onRegisteredSW(_swUrl, r) {
+      registration.current = r ?? null;
+    },
+  });
+
+  // The registration is read through a getter, not captured: when this effect
+  // runs, `onRegisteredSW` has not fired yet and the value is still null.
+  useEffect(() => watchForegroundUpdates(() => registration.current), []);
+
+  if (!needRefresh) return null;
+
+  const dismiss = () => {
+    // Hides the banner only. The waiting worker stays waiting, the app keeps
+    // running the version it started on, and the offer comes back next launch.
+    setNeedRefresh(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed left-4 right-4 md:left-auto md:right-4 md:w-96 z-50 animate-in slide-in-from-bottom-4 fade-in duration-300",
+        stacked ? "bottom-28" : "bottom-4",
+      )}
+      role="status"
+    >
+      <div className="rounded-lg border bg-card p-4 shadow-lg">
+        <div className="flex items-start gap-3">
+          <RefreshCw className="size-5 mt-0.5 shrink-0 text-primary" />
+          <div className="flex-1 min-w-0">
+            <p className="font-medium text-sm">{t("pwa.updateTitle")}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t("pwa.updateAvailable")}
+            </p>
+            <div className="flex items-center gap-2 mt-3">
+              <Button
+                size="sm"
+                onClick={() => {
+                  void updateServiceWorker(true);
+                }}
+              >
+                {t("pwa.update")}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={dismiss}>
+                {t("pwa.dismiss")}
+              </Button>
+            </div>
+          </div>
+          <button
+            onClick={dismiss}
+            aria-label={t("pwa.dismiss")}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -27,25 +26,12 @@ import { useCommandPalette } from "@/components/search";
 import { changeLanguage, getCurrentLanguage } from "@/i18n";
 import Logo from "@/assets/logo.svg?react";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useTheme } from "@/hooks/useTheme";
 import { isMac } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 
 interface TopBarProps {
-  onThemeToggle: () => void;
   onMobileMenuOpen: () => void;
-}
-
-/** Hook to track theme without causing parent re-renders */
-function useThemeIcon() {
-  const [isDark, setIsDark] = useState(() =>
-    typeof document !== "undefined" && document.documentElement.classList.contains("dark")
-  );
-  useEffect(() => {
-    const handler = (e: Event) => setIsDark((e as CustomEvent).detail === "dark");
-    window.addEventListener("zoned-theme-change", handler);
-    return () => window.removeEventListener("zoned-theme-change", handler);
-  }, []);
-  return isDark;
 }
 
 const touchTarget =
@@ -141,7 +127,7 @@ export function isNavActive(pathname: string, section: NavSection): boolean {
 // TopBar
 // ────────────────────────────────────────────────────────────────────────────
 
-export function TopBar({ onThemeToggle, onMobileMenuOpen }: TopBarProps) {
+export function TopBar({ onMobileMenuOpen }: TopBarProps) {
   const { t } = useTranslation("common");
   const { openPalette } = useCommandPalette();
   const currentLang = getCurrentLanguage();
@@ -149,8 +135,10 @@ export function TopBar({ onThemeToggle, onMobileMenuOpen }: TopBarProps) {
   // field and icon cluster — needs ~1100px and pushes the right-side icons
   // off-screen, so mid-size viewports use the compact hamburger layout.
   const isCompact = useMediaQuery("(max-width: 1023px)");
-  const isDark = useThemeIcon();
-  const theme = isDark ? "dark" : "light";
+  // Reading the resolved theme from context is what keeps this icon honest
+  // when the OS flips under a `system` preference. The button is a two-state
+  // light/dark switch; the third preference lives on /settings.
+  const { resolved: theme, toggle: onThemeToggle } = useTheme();
   const { pathname } = useLocation();
 
   return (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./useWorkouts";
 export { useTips } from "./useTips";
 export { usePWA } from "./usePWA";
+export { useTheme, ThemeProvider } from "./useTheme";
 
 // NOTE: useArticles and useGlossary are NOT exported here to avoid
 // pulling their data into the main bundle. Import them directly:

--- a/src/hooks/usePWA.ts
+++ b/src/hooks/usePWA.ts
@@ -8,11 +8,17 @@ interface BeforeInstallPromptEvent extends Event {
   userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
 }
 
+/**
+ * Install prompt and connectivity. Service worker *updates* are not here:
+ * they belong to <UpdatePrompt>, which owns the registration and the banner.
+ * This hook used to carry them, through a `zoned-sw-update` CustomEvent and a
+ * `window.__zonedApplyUpdate` global — a seam that only existed because the
+ * worker was registered outside the component tree.
+ */
 export function usePWA() {
   const [installEvent, setInstallEvent] =
     useState<BeforeInstallPromptEvent | null>(null);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
-  const [updateAvailable, setUpdateAvailable] = useState(false);
   const [installDismissed, setInstallDismissed] = useState(() => {
     const ts = localStorage.getItem(DISMISS_KEY);
     return ts ? Date.now() - Number(ts) < DISMISS_TTL : false;
@@ -25,18 +31,15 @@ export function usePWA() {
     };
     const onOnline = () => setIsOnline(true);
     const onOffline = () => setIsOnline(false);
-    const onUpdate = () => setUpdateAvailable(true);
 
     window.addEventListener("beforeinstallprompt", onInstallPrompt);
     window.addEventListener("online", onOnline);
     window.addEventListener("offline", onOffline);
-    window.addEventListener("zoned-sw-update", onUpdate);
 
     return () => {
       window.removeEventListener("beforeinstallprompt", onInstallPrompt);
       window.removeEventListener("online", onOnline);
       window.removeEventListener("offline", onOffline);
-      window.removeEventListener("zoned-sw-update", onUpdate);
     };
   }, []);
 
@@ -54,17 +57,10 @@ export function usePWA() {
     setInstallDismissed(true);
   }, []);
 
-  const applyUpdate = useCallback(() => {
-    const fn = (window as any).__zonedApplyUpdate;
-    if (typeof fn === "function") fn();
-  }, []);
-
   return {
     canInstall,
     promptInstall,
     dismissInstall,
     isOnline,
-    updateAvailable,
-    applyUpdate,
   };
 }

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,0 +1,88 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+import {
+  type ResolvedTheme,
+  type ThemePreference,
+  applyResolvedTheme,
+  prefersDark,
+  readStoredPreference,
+  resolveTheme,
+  storePreference,
+  watchSystemTheme,
+} from "@/lib/theme";
+
+interface ThemeContextValue {
+  /** What the user chose. `system` means "keep following the OS". */
+  preference: ThemePreference;
+  /** What is actually painted right now. */
+  resolved: ResolvedTheme;
+  setPreference: (preference: ThemePreference) => void;
+  /** Flips to the opposite of what is painted, as an explicit choice. */
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+/** `useSyncExternalStore` needs one for SSR; Zoned is a pure SPA. */
+const getServerSnapshot = (): boolean => false;
+
+/**
+ * Owns the theme preference and keeps the document in sync with it.
+ *
+ * The interesting part is `useSyncExternalStore` over `matchMedia`, which is
+ * what makes "I switch my phone to dark and the app follows" work with no
+ * polling and no listener to clean up by hand: the OS flips, the
+ * `MediaQueryList` emits `change`, React re-reads the snapshot, `resolved`
+ * flips, the effect writes the class. It is the same shape `MuscleMap` already
+ * uses to observe the class itself.
+ *
+ * Note the perf property the previous ref-based implementation was written for
+ * is preserved. `children` is an element created by the parent, so a preference
+ * change re-renders only actual `useTheme` consumers — the TopBar button and
+ * the settings card — never the page tree.
+ */
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useState<ThemePreference>(readStoredPreference);
+
+  const systemDark = useSyncExternalStore(watchSystemTheme, prefersDark, getServerSnapshot);
+  const resolved = resolveTheme(preference, systemDark);
+
+  useEffect(() => {
+    applyResolvedTheme(resolved);
+  }, [resolved]);
+
+  useEffect(() => {
+    storePreference(preference);
+  }, [preference]);
+
+  // Toggling out of `system` has to land on an explicit value, and the one the
+  // user expects is the opposite of what they are looking at — not the opposite
+  // of the preference, which is not a colour.
+  const toggle = useCallback(() => {
+    setPreference(resolved === "dark" ? "light" : "dark");
+  }, [resolved]);
+
+  const value = useMemo(
+    () => ({ preference, resolved, setPreference, toggle }),
+    [preference, resolved, toggle],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -395,6 +395,10 @@
   "settings": {
     "title": "Settings",
     "description": "Customize your experience",
+    "theme": {
+      "title": "Theme",
+      "description": "Light, dark, or follow your system"
+    },
     "colorPalette": {
       "title": "Color Palette",
       "description": "Adapted for visual accessibility",
@@ -743,6 +747,7 @@
     "installDesc": "Access Zoned directly from your home screen, even offline.",
     "install": "Install",
     "dismiss": "Later",
+    "updateTitle": "Update available",
     "updateAvailable": "A new version of Zoned is available.",
     "update": "Update",
     "offline": "You are offline. Your data remains accessible.",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -395,6 +395,10 @@
   "settings": {
     "title": "Paramètres",
     "description": "Personnalisez votre expérience",
+    "theme": {
+      "title": "Thème",
+      "description": "Clair, sombre ou selon votre système"
+    },
     "colorPalette": {
       "title": "Palette de couleurs",
       "description": "Adaptée à l'accessibilité visuelle",
@@ -743,6 +747,7 @@
     "installDesc": "Accédez à Zoned directement depuis votre écran d'accueil, même hors ligne.",
     "install": "Installer",
     "dismiss": "Plus tard",
+    "updateTitle": "Mise à jour disponible",
     "updateAvailable": "Une nouvelle version de Zoned est disponible.",
     "update": "Mettre à jour",
     "offline": "Vous êtes hors ligne. Vos données restent accessibles.",

--- a/src/lib/swUpdate.test.ts
+++ b/src/lib/swUpdate.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The foreground check exists to make the banner appear on a resumed PWA, and
+ * it has exactly one way to go wrong in production: asking too often. Requests
+ * for `sw.js` bypass the HTTP cache, so a listener without a floor turns every
+ * app-switch into a network round-trip — on mobile, on someone else's data.
+ *
+ * The other cases are the ones that would throw rather than misbehave: a
+ * registration that has not arrived yet, and an `update()` that rejects because
+ * the device is offline.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { UPDATE_CHECK_INTERVAL_MS, createUpdateChecker } from "./swUpdate";
+
+/** A clock the test moves by hand. */
+function fakeClock(start = 1_000_000) {
+  let value = start;
+  return {
+    now: () => value,
+    advance: (ms: number) => {
+      value += ms;
+    },
+  };
+}
+
+function fakeRegistration(update: () => Promise<unknown> = () => Promise.resolve()) {
+  return { update: mock(update) };
+}
+
+describe("createUpdateChecker", () => {
+  test("asks when the app becomes visible", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration();
+    const check = createUpdateChecker(() => registration, clock.now);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+
+    expect(check(true)).toBe(true);
+    expect(registration.update).toHaveBeenCalledTimes(1);
+  });
+
+  test("stays quiet when the app goes to the background", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration();
+    const check = createUpdateChecker(() => registration, clock.now);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+
+    expect(check(false)).toBe(false);
+    expect(registration.update).not.toHaveBeenCalled();
+  });
+
+  test("does not ask right after subscribing — the page load already compared sw.js", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration();
+    const check = createUpdateChecker(() => registration, clock.now);
+
+    expect(check(true)).toBe(false);
+    expect(registration.update).not.toHaveBeenCalled();
+  });
+
+  test("two returns inside a minute are one request", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration();
+    const check = createUpdateChecker(() => registration, clock.now);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+    expect(check(true)).toBe(true);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS - 1);
+    expect(check(true)).toBe(false);
+
+    expect(registration.update).toHaveBeenCalledTimes(1);
+  });
+
+  test("asks again once the floor has passed", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration();
+    const check = createUpdateChecker(() => registration, clock.now);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+    check(true);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+    expect(check(true)).toBe(true);
+
+    expect(registration.update).toHaveBeenCalledTimes(2);
+  });
+
+  test("survives a registration that has not arrived yet", () => {
+    const clock = fakeClock();
+    const check = createUpdateChecker(() => null, clock.now);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+
+    expect(() => check(true)).not.toThrow();
+    expect(check(true)).toBe(false);
+  });
+
+  test("reads the registration through the getter, not at build time", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration();
+    // Null at subscribe time, as it always is in the real app: `onRegisteredSW`
+    // has not fired when the effect runs.
+    let current: ReturnType<typeof fakeRegistration> | null = null;
+    const check = createUpdateChecker(() => current, clock.now);
+
+    current = registration;
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+
+    expect(check(true)).toBe(true);
+    expect(registration.update).toHaveBeenCalledTimes(1);
+  });
+
+  test("swallows an update() that rejects offline", () => {
+    const clock = fakeClock();
+    const registration = fakeRegistration(() => Promise.reject(new Error("offline")));
+    const check = createUpdateChecker(() => registration, clock.now);
+
+    clock.advance(UPDATE_CHECK_INTERVAL_MS);
+
+    expect(() => check(true)).not.toThrow();
+    expect(registration.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/swUpdate.ts
+++ b/src/lib/swUpdate.ts
@@ -1,0 +1,93 @@
+/**
+ * Update detection when the app comes back to the foreground.
+ *
+ * The browser only re-downloads and re-compares `sw.js` when a page loads. An
+ * installed PWA that the user *resumes* — it was backgrounded, not closed —
+ * loads no page: no comparison, no waiting worker, no banner, until the
+ * browser's own periodic check (~24 h) or a real restart. On a phone that is
+ * most sessions.
+ *
+ * The fix is to ask again whenever the app becomes visible. Asking is safe by
+ * construction: `registration.update()` can only ever install a new worker into
+ * the `waiting` state. With `registerType: "prompt"` and no `skipWaiting`
+ * anywhere, nothing activates it but the button in `UpdatePrompt`.
+ *
+ * The decision is split from the DOM wiring so it can be tested: `bun test`
+ * runs without a document.
+ */
+
+/**
+ * Two app-switches in a row are one question, not two. Requests for `sw.js`
+ * bypass the HTTP cache by default, so an unthrottled listener means a real
+ * network round-trip every time the user glances at another app.
+ */
+export const UPDATE_CHECK_INTERVAL_MS = 60_000;
+
+/**
+ * The part of `ServiceWorkerRegistration` that matters here. The resolved value
+ * is left open on purpose: the DOM lib types `update()` as `Promise<undefined>`
+ * in some versions and `Promise<ServiceWorkerRegistration>` in others, and we
+ * do nothing with it either way.
+ */
+type Updatable = { update: () => Promise<unknown> };
+
+export type UpdateChecker = (visible: boolean) => boolean;
+
+/**
+ * Builds a throttled update check. Returns whether it actually asked, which is
+ * what the tests assert on.
+ *
+ * `getRegistration` is a getter, not a value: at the moment a caller subscribes,
+ * the service worker has not finished registering, so capturing the value would
+ * pin `null` forever.
+ *
+ * `now` is injectable so the floor can be tested in milliseconds rather than in
+ * minutes.
+ */
+export function createUpdateChecker(
+  getRegistration: () => Updatable | null | undefined,
+  now: () => number = Date.now,
+): UpdateChecker {
+  // The page load that just happened already compared `sw.js`.
+  let lastCheck = now();
+
+  return (visible: boolean): boolean => {
+    if (!visible) return false;
+
+    const at = now();
+    if (at - lastCheck < UPDATE_CHECK_INTERVAL_MS) return false;
+    lastCheck = at;
+
+    const registration = getRegistration();
+    if (!registration) return false;
+
+    // Offline, or the server is unreachable: no unhandled rejection, no error
+    // in the console. We will ask again on the next return to the foreground.
+    void registration.update().catch(() => {});
+    return true;
+  };
+}
+
+/**
+ * Checks for an update whenever the document becomes visible, and hourly for a
+ * tab that is simply left open. Both paths share one checker, so they share one
+ * throttle. Returns the unsubscribe function.
+ */
+export function watchForegroundUpdates(
+  getRegistration: () => Updatable | null | undefined,
+  now: () => number = Date.now,
+): () => void {
+  if (typeof document === "undefined") return () => {};
+
+  const check = createUpdateChecker(getRegistration, now);
+  const onVisibilityChange = (): void => {
+    check(document.visibilityState === "visible");
+  };
+  const timer = setInterval(onVisibilityChange, 60 * 60 * 1000);
+
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  return () => {
+    clearInterval(timer);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  };
+}

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The theme preference is read from `localStorage` by two independent readers:
+ * this module, and the inline boot script in `index.html`. Both have to agree
+ * that anything they do not recognise means "follow the system" — a backup
+ * written by an older build, a hand-edited JSON, a half-cleared storage. What
+ * they must never do is leave the app unpainted or stuck on the wrong theme.
+ *
+ * `applyResolvedTheme` and `watchSystemTheme` are not covered here: they are
+ * DOM writes, and `bun test` has no DOM. They are kept deliberately thin for
+ * that reason — the branching lives in `resolveTheme`, which is pure.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  THEME_STORAGE_KEY,
+  type ThemePreference,
+  isThemePreference,
+  readStoredPreference,
+  resolveTheme,
+  storePreference,
+} from "./theme";
+
+// ── Minimal localStorage shim for bun test (jsdom-free) ────────────
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// Install once; Bun reuses the same globalThis between tests.
+if (typeof (globalThis as { localStorage?: Storage }).localStorage === "undefined") {
+  (globalThis as { localStorage: Storage }).localStorage =
+    new MemoryStorage() as unknown as Storage;
+}
+
+const PREFERENCES: ThemePreference[] = ["light", "dark", "system"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("isThemePreference", () => {
+  test("accepts exactly the three preferences", () => {
+    for (const preference of PREFERENCES) {
+      expect(isThemePreference(preference)).toBe(true);
+    }
+  });
+
+  test("rejects everything else", () => {
+    for (const value of [null, undefined, "", "Dark", "auto", "os", 0, {}, []]) {
+      expect(isThemePreference(value)).toBe(false);
+    }
+  });
+});
+
+describe("resolveTheme", () => {
+  test("an explicit preference ignores the system", () => {
+    expect(resolveTheme("light", true)).toBe("light");
+    expect(resolveTheme("light", false)).toBe("light");
+    expect(resolveTheme("dark", false)).toBe("dark");
+    expect(resolveTheme("dark", true)).toBe("dark");
+  });
+
+  test("system follows the OS", () => {
+    expect(resolveTheme("system", true)).toBe("dark");
+    expect(resolveTheme("system", false)).toBe("light");
+  });
+});
+
+describe("readStoredPreference", () => {
+  test("defaults to system when nothing is stored", () => {
+    expect(readStoredPreference()).toBe("system");
+  });
+
+  test("falls back to system on a value it does not recognise", () => {
+    // A restored backup from a build that stored something else, or a value
+    // edited by hand in the exported JSON.
+    for (const corrupt of ["purple", '"dark"', "DARK", "{}", ""]) {
+      localStorage.setItem(THEME_STORAGE_KEY, corrupt);
+      expect(readStoredPreference()).toBe("system");
+    }
+  });
+
+  test("reads back every preference it wrote", () => {
+    for (const preference of PREFERENCES) {
+      storePreference(preference);
+      expect(readStoredPreference()).toBe(preference);
+    }
+  });
+
+  test("stores a bare string, not JSON — the boot script cannot parse", () => {
+    storePreference("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,142 @@
+/**
+ * Theme — the one place a preference becomes a painted theme.
+ *
+ * Three preferences, not two: `light`, `dark` and `system`. The distinction
+ * matters because `system` has to keep following the OS *after* the choice is
+ * made. What existed before was a binary toggle plus a "has the user ever
+ * touched it" flag, so the first tap on the sun/moon button killed OS
+ * following for good, with no way back.
+ *
+ * The preference lives in `localStorage["zoned-theme"]` as a bare string, and
+ * that shape is load-bearing: the inline script in `index.html` reads it before
+ * the first paint to avoid a flash of the wrong theme, and it can only afford
+ * one `getItem` — no JSON, no async, no imports. Anything unrecognised (an
+ * older build, a hand-edited backup, a corrupted value) resolves to `system`.
+ *
+ * The resolved theme is written to the DOM as Tailwind's `.dark` class, which
+ * `@custom-variant dark (&:is(.dark *))` in `src/styles/index.css` and the
+ * `.dark` block in `src/styles/themes.css` both key off.
+ */
+
+export type ThemePreference = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "zoned-theme";
+
+/**
+ * Browser-chrome colour per resolved theme — mirrors `--background` in
+ * `src/styles/themes.css` (`:root` for light, `.dark` for dark).
+ *
+ * Duplicated in the inline boot script in `index.html`, which cannot import
+ * from here. Change one, change the other.
+ */
+const THEME_COLOR: Record<ResolvedTheme, string> = {
+  light: "#f8fafc",
+  dark: "#0b1120",
+};
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+/** Reads the OS preference. `false` wherever `matchMedia` is unavailable. */
+export function prefersDark(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+/**
+ * `systemDark` is a parameter rather than a call to `prefersDark()` so this
+ * stays pure — `bun test` runs without a DOM, and this is the branch worth
+ * testing.
+ */
+export function resolveTheme(
+  preference: ThemePreference,
+  systemDark: boolean,
+): ResolvedTheme {
+  if (preference === "system") return systemDark ? "dark" : "light";
+  return preference;
+}
+
+export function readStoredPreference(): ThemePreference {
+  try {
+    const raw = localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemePreference(raw) ? raw : "system";
+  } catch {
+    // Private mode can throw on access. Following the OS is the right default
+    // for a browser that will not remember the answer anyway.
+    return "system";
+  }
+}
+
+export function storePreference(preference: ThemePreference): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, preference);
+  } catch {
+    // Private mode, full quota: the theme still applies for this session, it
+    // just will not survive a reload. Nothing worth interrupting the user for.
+  }
+}
+
+/** The resolved theme currently on the document, to skip redundant writes. */
+let applied: ResolvedTheme | null = null;
+
+/**
+ * Writes the resolved theme to `<html>`. Four things, and all four count:
+ *
+ * 1. The `.dark` class — what the CSS reads. Always via `classList.toggle`,
+ *    never `className =`: the same element also carries `palette-deuteranopia`
+ *    / `palette-tritanopia`, which `palettes-a11y.css` combines as
+ *    `.palette-*.dark`.
+ * 2. `style.colorScheme` — tells the browser to render *native* controls
+ *    (scrollbars, `<input type="date">`, autofill, `<select>`) in the right
+ *    shade. Its absence is why a dark Zoned still had white scrollbars.
+ * 3. The `theme-color` meta without a `media` attribute — the system bar colour
+ *    on mobile. See the comment in `index.html`: a `media`-scoped meta follows
+ *    the OS and would contradict an explicit choice.
+ * 4. `data-switching-theme`, which `themes.css` uses to zero every transition
+ *    for the duration of the swap. Only on an actual change, so a repaint that
+ *    resolves to the same theme costs nothing.
+ */
+export function applyResolvedTheme(resolved: ResolvedTheme): void {
+  if (typeof document === "undefined") return;
+
+  const root = document.documentElement;
+  const changed = applied !== null && applied !== resolved;
+  applied = resolved;
+
+  if (changed) root.setAttribute("data-switching-theme", "");
+
+  root.classList.toggle("dark", resolved === "dark");
+  root.style.colorScheme = resolved;
+
+  const meta = document.querySelector('meta[name="theme-color"]:not([media])');
+  if (meta) meta.setAttribute("content", THEME_COLOR[resolved]);
+
+  if (changed) {
+    // Two frames: one for the class to take effect, one for the browser to
+    // paint it, before transitions are allowed back.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        root.removeAttribute("data-switching-theme");
+      });
+    });
+  }
+}
+
+/**
+ * Subscribes to the OS theme. Returns the unsubscribe function, shaped for
+ * `useSyncExternalStore`.
+ */
+export function watchSystemTheme(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const media = window.matchMedia("(prefers-color-scheme: dark)");
+  media.addEventListener("change", onChange);
+  return () => {
+    media.removeEventListener("change", onChange);
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,38 +24,8 @@ createRoot(document.getElementById("root")!).render(
 // Hide shell after first paint
 requestAnimationFrame(hideLoadingShell);
 
-// PWA service worker registration.
-// Strategy: auto-reload silently when an update is detected within the first
-// few seconds (typical refresh case — user expects fresh content). Otherwise
-// surface the banner so we don't interrupt an in-flight action.
-if ("serviceWorker" in navigator && import.meta.env.PROD) {
-  const APP_LOADED_AT = Date.now();
-  const SILENT_RELOAD_WINDOW_MS = 10_000;
-  const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
-
-  import("virtual:pwa-register").then(({ registerSW }) => {
-    const updateSW = registerSW({
-      immediate: true,
-      onNeedRefresh() {
-        const elapsed = Date.now() - APP_LOADED_AT;
-        if (elapsed < SILENT_RELOAD_WINDOW_MS) {
-          updateSW(true);
-          return;
-        }
-        window.dispatchEvent(new CustomEvent("zoned-sw-update"));
-        (window as any).__zonedApplyUpdate = () => updateSW(true);
-      },
-      onRegisteredSW(_swUrl, registration) {
-        if (!registration) return;
-        const checkForUpdate = () => {
-          if (registration.installing || !navigator.onLine) return;
-          registration.update().catch(() => {});
-        };
-        document.addEventListener("visibilitychange", () => {
-          if (document.visibilityState === "visible") checkForUpdate();
-        });
-        setInterval(checkForUpdate, UPDATE_CHECK_INTERVAL_MS);
-      },
-    });
-  });
-}
+// The service worker is registered by <UpdatePrompt> (src/components/domain),
+// which owns the update banner. It used to be registered here, with a rule that
+// silently reloaded the page when an update arrived within 10s of load — a
+// reload nobody asked for, on an app whose data is entirely local. Nothing
+// reloads now but the button in that banner.

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { DataExportImport } from "@/components/domain/DataExportImport";
+import { useTheme } from "@/hooks/useTheme";
+import type { ThemePreference } from "@/lib/theme";
 import type { ColorPalette } from "@/types/settings";
 
 const ZONE_NUMBERS = [1, 2, 3, 4, 5, 6] as const;
@@ -45,6 +47,13 @@ export function SettingsPage() {
   const { t } = useTranslation(["common", "routes"]);
   const { settings, setColorPalette, setUnitSystem, setRouteGeneratorEnabled } =
     useSettings();
+  const { preference: themePreference, setPreference: setThemePreference } = useTheme();
+
+  const themeOptions: { value: ThemePreference; label: string }[] = [
+    { value: "light", label: t("theme.light") },
+    { value: "dark", label: t("theme.dark") },
+    { value: "system", label: t("theme.system") },
+  ];
 
   const paletteOptions: { value: ColorPalette; label: string }[] = [
     {
@@ -77,6 +86,33 @@ export function SettingsPage() {
         </div>
 
         <div className="space-y-6">
+          {/* Theme. `system` is the only option that keeps following the OS
+              after the choice is made — the TopBar button can only ever set an
+              explicit light or dark. */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t("settings.theme.title")}</CardTitle>
+              <CardDescription>{t("settings.theme.description")}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Select
+                value={themePreference}
+                onValueChange={(value) => setThemePreference(value as ThemePreference)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {themeOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </CardContent>
+          </Card>
+
           {/* Color Palette */}
           <Card>
             <CardHeader>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+// `virtual:pwa-register/react`, used by <UpdatePrompt>. Referenced here rather
+// than listed in tsconfig `types`: that route pulls in workbox's own types,
+// which are written for a service worker and would demand the WebWorker lib
+// (self, ExtendableEvent…) across browser code.
+/// <reference types="vite-plugin-pwa/react" />
 
 declare module "*.svg?react" {
   import { FunctionComponent, SVGProps } from "react";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     svgr(),
     tailwindcss(),
     VitePWA({
-      registerType: "autoUpdate",
+      // "prompt", not "autoUpdate": a new service worker installs, precaches,
+      // then sits in `waiting` until <UpdatePrompt> is told to activate it.
+      // Every byte of user data lives in this browser, so a deploy must never
+      // reload the page out from under someone mid-edit.
+      registerType: "prompt",
       includeAssets: ["favicon.svg", "favicon-32x32.png", "favicon-16x16.png"],
       manifest: {
         // English strings: the install prompt is the first thing an
@@ -100,16 +104,20 @@ export default defineConfig({
         // router receives /licenses.txt, matches nothing and renders its 404 —
         // while curl, having no service worker, gets the real file. No route
         // ends in .txt or .xml, so the pattern cannot swallow a real page.
+        navigateFallback: "/index.html",
         navigateFallbackDenylist: [/\.(txt|xml)$/],
-        // skipWaiting + clientsClaim: the new SW activates as soon as it's
-        // installed, instead of waiting for every tab to close. Mobile users
-        // never "close all tabs" (they just background the browser), so without
-        // this they're permanently stuck on whatever version was first cached.
-        // The trade-off: in-flight lazy chunks pointing to old hashes can 404
-        // mid-navigation; we accept that — a soft reload recovers, and a stale
-        // app is worse than one occasional refresh.
-        skipWaiting: true,
-        clientsClaim: true,
+        // No skipWaiting, no clientsClaim, deliberately. Together with
+        // registerType "prompt" they are the whole guarantee: with neither set,
+        // no code path can activate a new version behind the app's back.
+        //
+        // These two used to be true, on the reasoning that mobile users never
+        // "close all tabs" and would otherwise be stranded on the first version
+        // they cached. That problem is real, and the banner is what answers it:
+        // `watchForegroundUpdates` re-checks whenever the app comes back to the
+        // foreground, so a resumed PWA is *asked*, not stranded. The 404s that
+        // comment accepted — in-flight lazy chunks pointing at hashes the new
+        // worker no longer serves — stop happening too, because the old worker
+        // keeps serving its own precache until the user consents.
       },
     }),
   ],


### PR DESCRIPTION
Two mechanisms that both come down to the same thing: the app doing something
the user did not ask for.

Theme. There were two preferences, not three. "Follow the OS" was not a value
anyone could choose — it was the absence of one, inferred from
`localStorage.getItem("zoned-theme") !== null`, and the media-query listener in
App.tsx was gated on that ref. So the first tap on the sun/moon button ended OS
following for that browser permanently, with no way back to it. `theme.system`
had been sitting unused in both locale files.

The preference is now a real tri-state living in the same `zoned-theme` key, as
a bare string so the inline boot script can still read it with one getItem
before the first paint. Anything unrecognised — an old backup, a hand-edited
export — resolves to `system` rather than breaking the render. `system` follows
the OS live, through useSyncExternalStore over matchMedia: the OS flips, the
MediaQueryList emits, `resolved` flips, an effect writes the class. The
ref-based design existed to avoid re-rendering the tree on a theme change, and
that property is kept — `children` is a stable element, so only the two actual
consumers re-render.

Three things came out of doing this properly. `style.colorScheme` is now
written, which is what native controls read; without it scrollbars, date
pickers and autofill stayed light inside the dark theme. The two `theme-color`
metas were both `media`-scoped, so the status bar followed the OS and
contradicted an explicit choice — they are replaced by one un-`media`'d tag
that JS drives. And the TopBar icon read the theme off a CustomEvent the
OS-driven path never dispatched, so it went stale on a system flip; it reads
context now, and the event is gone with its only listener.

Updates. `registerType: "autoUpdate"` with skipWaiting + clientsClaim meant a
new worker took over on its own, and main.tsx reloaded the page outright if an
update landed within 10s of load. Everything Zoned holds is in the browser; a
deploy could take a workout in progress with it. The old comment defended this
on the grounds that mobile users never close all tabs and would be stranded on
a stale version. That problem is real — the banner is the answer to it, not
skipWaiting: a resumed PWA loads no page and so compares no sw.js, which is why
watchForegroundUpdates re-checks on visibilitychange, floored at a minute
because those requests bypass the HTTP cache. Users get asked, not stranded,
and the lazy-chunk 404s that comment accepted stop happening too, since the old
worker keeps serving its own precache until the user consents.

Registration moves into the component that owns the banner, which drops the
`window.__zonedApplyUpdate` any-global and the CustomEvent hop, and gives
"Later" a real dismissal instead of a toast that returned on the next poll.

The decision logic in both features is pure and unit-tested; the DOM wiring
over it is deliberately thin, since bun test runs without a document.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hb7w1j6fyuyvNesR83ywBM