### PR TITLE
fix(export): let a session with no warmup reach its PDF

### DIFF
--- a/src/lib/export/pdf.test.ts
+++ b/src/lib/export/pdf.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Export layer: single workout → PDF.
+ *
+ * The one invariant these tests exist for: **every row of a phase table must
+ * carry exactly as many cells as the table has columns.** pdfmake 0.3 walks
+ * each row against `widths` and throws `Malformed table row, a cell is
+ * undefined` on a short one — it does not pad. The empty-phase placeholder
+ * used to be a single-cell row in a five-column table, so `exportToPDF` threw
+ * for every session with no warmup or no cooldown (the recovery runs, CYC-001)
+ * and the UI turned that into "export failed".
+ *
+ * The fixtures below are built by hand rather than pulled from the catalogue:
+ * the point is to pin the *shapes* the renderer must survive (empty phase,
+ * absent phase, populated phase), and those must keep being covered even if
+ * every recovery run in the catalogue grows a warmup tomorrow.
+ *
+ * Two things are stubbed, both because they cannot load under `bun test`, and
+ * both the same way `planPdf.test.ts` does it:
+ *  - `@/i18n` is a Vite module (`import.meta.glob`); the stub returns the raw
+ *    key so assertions never freeze French copy.
+ *  - `pdfmake` renders to a browser canvas. The stub captures the document
+ *    definition, which IS what this module produces.
+ *
+ * The stub means these tests assert the row shape rather than watch pdfmake
+ * accept it. That is deliberate — the shape is the contract pdfmake enforces —
+ * but it also means a green run here is not proof the real renderer is happy.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { WorkoutBlock, WorkoutTemplate } from "@/types";
+
+mock.module("@/i18n", () => ({
+  default: {
+    language: "fr",
+    t: (key: string) => key,
+  },
+}));
+
+/** Last document definition handed to pdfmake, captured by the stub below. */
+let lastDoc: { content?: unknown } | null = null;
+
+function captured(): { content?: unknown } {
+  if (!lastDoc) throw new Error("pdfmake.createPdf was never called");
+  return lastDoc;
+}
+
+mock.module("pdfmake/build/pdfmake", () => ({
+  default: {
+    vfs: {},
+    createPdf: (doc: { content?: unknown }) => {
+      lastDoc = doc;
+      return { getBlob: async () => new Blob(["%PDF-1.7"], { type: "application/pdf" }) };
+    },
+  },
+}));
+
+mock.module("pdfmake/build/vfs_fonts", () => ({ default: { vfs: {} } }));
+
+const { exportToPDF } = await import("./pdf");
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+function block(overrides: Partial<WorkoutBlock> = {}): WorkoutBlock {
+  return {
+    description: "Bloc",
+    descriptionEn: "Block",
+    durationMin: 10,
+    zone: "Z2",
+    ...overrides,
+  } as WorkoutBlock;
+}
+
+/**
+ * A running template with only the fields `exportToPDF` reads. `category` and
+ * `difficulty` must be real keys — the renderer indexes CATEGORY_META and
+ * DIFFICULTY_META with them.
+ */
+function workout(overrides: Partial<WorkoutTemplate> = {}): WorkoutTemplate {
+  return {
+    id: "TEST-001",
+    name: "Séance test",
+    nameEn: "Test session",
+    description: "Description",
+    descriptionEn: "Description",
+    category: "recovery",
+    difficulty: "beginner",
+    warmupTemplate: [block()],
+    mainSetTemplate: [block({ durationMin: 30 })],
+    cooldownTemplate: [block()],
+    coachingTips: ["Conseil"],
+    coachingTipsEn: ["Tip"],
+    commonMistakes: ["Erreur"],
+    commonMistakesEn: ["Mistake"],
+    ...overrides,
+  } as WorkoutTemplate;
+}
+
+// ── Harness ─────────────────────────────────────────────────────────
+
+/**
+ * `exportToPDF` ends on a DOM download. Bun has no `document`, so we install a
+ * minimal one; the captured document definition is what we assert on.
+ */
+async function runExport(template: WorkoutTemplate): Promise<{ filename: string }> {
+  lastDoc = null;
+
+  const anchor = { href: "", download: "", click: () => {} };
+  const fakeDocument = {
+    createElement: () => anchor,
+    body: { appendChild: () => {}, removeChild: () => {} },
+  };
+
+  const realCreate = URL.createObjectURL;
+  const realRevoke = URL.revokeObjectURL;
+  Object.defineProperty(globalThis, "document", { value: fakeDocument, configurable: true });
+  URL.createObjectURL = () => "blob:zoned-test";
+  URL.revokeObjectURL = () => {};
+
+  try {
+    await exportToPDF(template);
+  } finally {
+    URL.createObjectURL = realCreate;
+    URL.revokeObjectURL = realRevoke;
+    Reflect.deleteProperty(globalThis, "document");
+  }
+
+  return { filename: anchor.download };
+}
+
+/** Every table in the content tree, with the widths it declared. */
+function phaseTables(): { widths: unknown[]; body: unknown[][] }[] {
+  const out: { widths: unknown[]; body: unknown[][] }[] = [];
+  const walk = (node: unknown) => {
+    if (node == null || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    const record = node as Record<string, unknown>;
+    const table = record.table as { body?: unknown[][]; widths?: unknown[] } | undefined;
+    if (table?.body && Array.isArray(table.widths)) {
+      out.push({ widths: table.widths, body: table.body });
+    }
+    Object.values(record).forEach(walk);
+  };
+  walk(captured().content);
+  return out;
+}
+
+/**
+ * How many columns a row occupies by pdfmake's reckoning: one per cell, and a
+ * `colSpan: n` cell still counts as one because the n-1 filler cells that must
+ * follow it are themselves in the row.
+ */
+function cellCount(row: unknown[]): number {
+  return row.length;
+}
+
+beforeEach(() => {
+  lastDoc = null;
+});
+
+describe("exportToPDF", () => {
+  test("emits the three phase tables", async () => {
+    await runExport(workout());
+    // Warmup, main set, cooldown — all five columns wide.
+    const tables = phaseTables();
+    expect(tables).toHaveLength(3);
+    for (const table of tables) {
+      expect(table.widths).toHaveLength(5);
+    }
+  });
+
+  test("names the file after the workout id", async () => {
+    const { filename } = await runExport(workout({ id: "REC-001" }));
+    expect(filename).toBe("REC-001.pdf");
+  });
+
+  // ── The regression ────────────────────────────────────────────────
+
+  test("every row of every phase table is as wide as the table", async () => {
+    await runExport(
+      workout({
+        warmupTemplate: [],
+        mainSetTemplate: [block({ durationMin: 30 })],
+        cooldownTemplate: [],
+      }),
+    );
+
+    for (const table of phaseTables()) {
+      for (const row of table.body) {
+        expect(cellCount(row)).toBe(table.widths.length);
+      }
+    }
+  });
+
+  test("an empty phase renders a placeholder spanning the whole row", async () => {
+    await runExport(workout({ warmupTemplate: [] }));
+
+    const warmup = phaseTables()[0];
+    // Row 0 is the header; row 1 is the placeholder.
+    expect(warmup.body).toHaveLength(2);
+
+    const [placeholder, ...filler] = warmup.body[1] as Record<string, unknown>[];
+    expect(placeholder.text).toBe("common:export.workoutPdf.none");
+    expect(placeholder.colSpan).toBe(5);
+    // colSpan swallows the next four cells, but they must still be present.
+    expect(filler).toHaveLength(4);
+    expect(filler.every((cell) => Object.keys(cell).length === 0)).toBe(true);
+  });
+
+  test.each([
+    ["warmupTemplate", { warmupTemplate: [] }],
+    ["cooldownTemplate", { cooldownTemplate: [] }],
+    ["both warmup and cooldown", { warmupTemplate: [], cooldownTemplate: [] }],
+    ["mainSetTemplate", { mainSetTemplate: [] }],
+  ] as const)("exports a session with an empty %s", async (_label, overrides) => {
+    await expect(runExport(workout(overrides))).resolves.toBeDefined();
+  });
+
+  test("survives a phase array that is absent entirely", async () => {
+    // `warmupTemplate` / `cooldownTemplate` are optional on
+    // WorkoutStructureSource, and a custom workout restored from localStorage
+    // can arrive without them.
+    const partial = workout();
+    Reflect.deleteProperty(partial, "warmupTemplate");
+    Reflect.deleteProperty(partial, "cooldownTemplate");
+
+    await expect(runExport(partial)).resolves.toBeDefined();
+
+    for (const table of phaseTables()) {
+      for (const row of table.body) {
+        expect(cellCount(row)).toBe(table.widths.length);
+      }
+    }
+  });
+});

--- a/src/lib/export/pdf.ts
+++ b/src/lib/export/pdf.ts
@@ -4,7 +4,7 @@
  * Creates comprehensive PDF documents from workout templates
  */
 
-import type { TDocumentDefinitions, Content, TableCell } from "pdfmake/interfaces";
+import type { TDocumentDefinitions, Content, Size, TableCell } from "pdfmake/interfaces";
 import type { WorkoutTemplate, WorkoutBlock } from "@/types";
 import { CATEGORY_META, DIFFICULTY_META, getZoneNumber } from "@/types";
 import { getZoneHex } from "@/lib/zoneColors";
@@ -26,11 +26,38 @@ function zoneColorFor(zoneSpec: string | undefined): string | undefined {
 }
 
 /**
- * Format blocks into table rows for PDF
+ * Geometry of the three phase tables (warmup / main set / cooldown). Declared
+ * once because every row has to match it: pdfmake validates the cell count of
+ * each row against the column count and throws on a mismatch.
  */
-function formatBlocksTable(blocks: WorkoutBlock[]): TableCell[][] {
-  if (blocks.length === 0) {
-    return [[{ text: i18n.t("common:export.workoutPdf.none"), italics: true, color: "#666" }]];
+const PHASE_TABLE_WIDTHS: Size[] = ["*", 50, 40, 35, 50];
+const PHASE_TABLE_COLUMNS = PHASE_TABLE_WIDTHS.length;
+
+/**
+ * Format blocks into table rows for PDF
+ *
+ * `blocks` is optional: `warmupTemplate` and `cooldownTemplate` are optional on
+ * `WorkoutStructureSource`, and a custom workout restored from localStorage can
+ * genuinely arrive without them.
+ */
+function formatBlocksTable(blocks: WorkoutBlock[] | undefined): TableCell[][] {
+  if (!blocks || blocks.length === 0) {
+    // The placeholder has to span the whole table, not sit in a one-cell row.
+    // pdfmake 0.3 rejects a short row outright — "Malformed table row, a cell
+    // is undefined" — which broke every session with an empty phase (the
+    // recovery runs, CYC-001). `colSpan` also has to be followed by the empty
+    // cells it swallows, or the row is short again by pdfmake's count.
+    return [
+      [
+        {
+          text: i18n.t("common:export.workoutPdf.none"),
+          italics: true,
+          color: "#666",
+          colSpan: PHASE_TABLE_COLUMNS,
+        },
+        ...Array.from({ length: PHASE_TABLE_COLUMNS - 1 }, () => ({}) as TableCell),
+      ],
+    ];
   }
 
   return blocks.map((block) => {
@@ -112,7 +139,7 @@ export async function exportToPDF(
       {
         table: {
           headerRows: 1,
-          widths: ["*", 50, 40, 35, 50],
+          widths: PHASE_TABLE_WIDTHS,
           body: [tableHeader, ...formatBlocksTable(workout.warmupTemplate)],
         },
         layout: "lightHorizontalLines",
@@ -124,7 +151,7 @@ export async function exportToPDF(
       {
         table: {
           headerRows: 1,
-          widths: ["*", 50, 40, 35, 50],
+          widths: PHASE_TABLE_WIDTHS,
           body: [tableHeader, ...formatBlocksTable(workout.mainSetTemplate)],
         },
         layout: "lightHorizontalLines",
@@ -136,7 +163,7 @@ export async function exportToPDF(
       {
         table: {
           headerRows: 1,
-          widths: ["*", 50, 40, 35, 50],
+          widths: PHASE_TABLE_WIDTHS,
           body: [tableHeader, ...formatBlocksTable(workout.cooldownTemplate)],
         },
         layout: "lightHorizontalLines",


### PR DESCRIPTION
Exporting a recovery run failed with "export failed": the eleven
catalogue sessions that leave a phase empty (REC-001/003/004/006/007/
008/009/010/013/016 and CYC-001) all threw before producing a file, as
did any custom workout built without a warmup or a cooldown.

The phase tables are five columns wide, but the "no blocks here"
placeholder was emitted as a one-cell row. pdfmake walks each row against
`widths` and refuses to pad a short one -- "Malformed table row, a cell is
undefined" -- so the row that stands for an empty phase was the one row it
would not accept. The placeholder now carries `colSpan` over the full
width, followed by the empty cells that colSpan consumes, which is what
the plan exporter already does for its own spanning rows.

`widths` was written out at all three call sites; it is one constant now,
so the column count the placeholder spans cannot drift from the tables it
spans.

Also stop assuming the phase arrays exist. `warmupTemplate` and
`cooldownTemplate` are optional on WorkoutStructureSource, and custom
workouts are rehydrated from arbitrary localStorage JSON, so a missing
array is reachable rather than hypothetical; it now renders the same
placeholder instead of throwing on `.length`.

Covered by src/lib/export/pdf.test.ts, which pins the invariant that
actually matters -- every row is as wide as its table -- across empty,
absent and populated phases. Verified against the real renderer too: all
256 catalogue sessions now produce a PDF, where 28 threw before.